### PR TITLE
fix(websocket): StompJwtChannelIntercepter클래스 수정

### DIFF
--- a/src/main/java/com/example/junggoheaven/global/websocket/StompJwtChannelInterceptor.java
+++ b/src/main/java/com/example/junggoheaven/global/websocket/StompJwtChannelInterceptor.java
@@ -8,6 +8,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.util.StringUtils;
 
 import java.security.Principal;
@@ -18,7 +19,8 @@ public class StompJwtChannelInterceptor implements ChannelInterceptor {
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        StompHeaderAccessor accessor = MessageHeaderAccessor
+                .getAccessor(message, StompHeaderAccessor.class);
 
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             String tokenValue = accessor.getFirstNativeHeader("Authorization");


### PR DESCRIPTION
죄송합니다.
어제 문제였던 부분을 수정했는데 올리고 보니까 수정 전으로 되어있었네요..

StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);

->>          StompHeaderAccessor accessor = MessageHeaderAccessor
                .getAccessor(message, StompHeaderAccessor.class);
