### PR TITLE
Feat/like

### DIFF
--- a/src/main/java/com/example/junggoheaven/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/controller/LikeController.java
@@ -53,7 +53,7 @@ public class LikeController {
 		return ResponseDto.success(likeService.getPopularProducts());
 	}
 
-	@DeleteMapping("/likes/{likeId}}")
+	@DeleteMapping("/likes/{likeId}")
 	public ResponseDto<Void> deleteProductLikes(@AuthenticationPrincipal AuthUser authUser,
 		@PathVariable Long likeId) {
 		likeService.deleteProductLikes(authUser.getId(), likeId);

--- a/src/main/java/com/example/junggoheaven/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/controller/LikeController.java
@@ -1,0 +1,69 @@
+package com.example.junggoheaven.domain.like.controller;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.junggoheaven.domain.like.dto.LikeProductResponseDto;
+import com.example.junggoheaven.domain.like.dto.LikeRequestDto;
+import com.example.junggoheaven.domain.like.dto.LikeResponseDto;
+import com.example.junggoheaven.domain.like.service.LikeService;
+import com.example.junggoheaven.domain.user.enums.UserRole;
+import com.example.junggoheaven.global.auth.dto.user.AuthUser;
+import com.example.junggoheaven.global.common.response.ResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class LikeController {
+
+	private final LikeService likeService;
+
+	@PostMapping("/likes")
+	public ResponseDto<LikeResponseDto> createLike(@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody LikeRequestDto requestDto) {
+		return ResponseDto.success(likeService.createLike(authUser.getId(), requestDto));
+	}
+
+	@GetMapping("/likes/my")
+	public ResponseDto<Page<LikeProductResponseDto>> getMyLikeProducts(@AuthenticationPrincipal AuthUser authUser,
+		@RequestParam(defaultValue = "0") int pageNumber, @RequestParam(defaultValue = "10") int pageSize) {
+		return ResponseDto.success(likeService.getMyLikeProducts(authUser.getId(), pageNumber, pageSize));
+	}
+
+	@GetMapping("/likes/products/{productId}")
+	public ResponseDto<LikeResponseDto> getProductLikes(@PathVariable Long productId) {
+		return ResponseDto.success(likeService.getProductLikes(productId));
+	}
+
+	@GetMapping("/likes/best")
+	public ResponseDto<List<LikeProductResponseDto>> getPopularProducts() {
+		return ResponseDto.success(likeService.getPopularProducts());
+	}
+
+	@DeleteMapping("/likes/{likeId}}")
+	public ResponseDto<Void> deleteProductLikes(@AuthenticationPrincipal AuthUser authUser,
+		@PathVariable Long likeId) {
+		likeService.deleteProductLikes(authUser.getId(), likeId);
+		return ResponseDto.success(null);
+	}
+
+	@Secured(UserRole.Authority.ADMIN)
+	@GetMapping("/likes/users/{userId}")
+	public ResponseDto<Page<LikeProductResponseDto>> getProductsOfUser(@PathVariable Long userId,
+		@RequestParam(defaultValue = "0") int pageNumber, @RequestParam(defaultValue = "10") int pageSize) {
+		return ResponseDto.success(likeService.getProductsOfUser(userId, pageNumber, pageSize));
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/dto/LikeProductResponseDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/dto/LikeProductResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.junggoheaven.domain.like.dto;
 
 import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.product.entity.Product;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,13 @@ public class LikeProductResponseDto {
 		return LikeProductResponseDto.builder()
 			.id(like.getProduct().getId())
 			.name(like.getProduct().getName())
+			.build();
+	}
+
+	public static LikeProductResponseDto from(Product product) {
+		return LikeProductResponseDto.builder()
+			.id(product.getId())
+			.name(product.getName())
 			.build();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/domain/like/dto/LikeProductResponseDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/dto/LikeProductResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.junggoheaven.domain.like.dto;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LikeProductResponseDto {
+	private Long productId;
+	private String product;
+
+	@Builder
+	private LikeProductResponseDto(Long id, String name) {
+		this.productId = id;
+		this.product = name;
+	}
+
+	public static LikeProductResponseDto from(Like like) {
+		return LikeProductResponseDto.builder()
+			.id(like.getProduct().getId())
+			.name(like.getProduct().getName())
+			.build();
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/dto/LikeRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/dto/LikeRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.junggoheaven.domain.like.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeRequestDto {
+	@NotBlank(message = "좋아요 누를 상품을 선택해주세요.")
+	private Long productId;
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/dto/LikeResponseDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/dto/LikeResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.junggoheaven.domain.like.dto;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LikeResponseDto {
+	private Long productId;
+	private String product;
+	private int count;
+
+	@Builder
+	private LikeResponseDto(Long productId, String product, int count) {
+		this.productId = productId;
+		this.product = product;
+		this.count = count;
+	}
+
+	public static LikeResponseDto from(Like like, int count) {
+		return LikeResponseDto.builder()
+			.productId(like.getProduct().getId())
+			.product(like.getProduct().getName())
+			.count(count)
+			.build();
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/dto/LikeResponseDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/dto/LikeResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.junggoheaven.domain.like.dto;
 
 import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.product.entity.Product;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +23,14 @@ public class LikeResponseDto {
 		return LikeResponseDto.builder()
 			.productId(like.getProduct().getId())
 			.product(like.getProduct().getName())
+			.count(count)
+			.build();
+	}
+
+	public static LikeResponseDto from(Product product, int count) {
+		return LikeResponseDto.builder()
+			.productId(product.getId())
+			.product(product.getName())
 			.count(count)
 			.build();
 	}

--- a/src/main/java/com/example/junggoheaven/domain/like/entity/Like.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/entity/Like.java
@@ -13,10 +13,13 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(uniqueConstraints = @UniqueConstraint(name = "unique_product_user", columnNames = {"product_id", "users_id"}))
+@NoArgsConstructor
+@Table(name = "likes"
+	, uniqueConstraints = @UniqueConstraint(name = "unique_product_user", columnNames = {"product_id", "users_id"}))
 public class Like {
 
 	@Id

--- a/src/main/java/com/example/junggoheaven/domain/like/entity/Like.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/entity/Like.java
@@ -1,0 +1,36 @@
+package com.example.junggoheaven.domain.like.entity;
+
+import com.example.junggoheaven.domain.product.entity.Product;
+import com.example.junggoheaven.domain.user.entity.User;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(uniqueConstraints = @UniqueConstraint(name = "unique_product_user", columnNames = {"product_id", "users_id"}))
+public class Like {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id", nullable = false)
+	private Product product;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "users_id", nullable = false)
+	private User user;
+
+	public Like(Product product, User user) {
+		this.product = product;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/exception/AlreadyLikesException.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/exception/AlreadyLikesException.java
@@ -1,0 +1,7 @@
+package com.example.junggoheaven.domain.like.exception;
+
+public class AlreadyLikesException extends LikeException{
+	public AlreadyLikesException(){
+		super(LikeErrorCode.ALREADY_LIKES);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/exception/InvalidLikesException.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/exception/InvalidLikesException.java
@@ -1,0 +1,7 @@
+package com.example.junggoheaven.domain.like.exception;
+
+public class InvalidLikesException extends LikeException{
+	public InvalidLikesException() {
+		super(LikeErrorCode.INVALID_LIKES);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/exception/LikeDeletionException.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/exception/LikeDeletionException.java
@@ -1,0 +1,7 @@
+package com.example.junggoheaven.domain.like.exception;
+
+public class LikeDeletionException extends LikeException{
+	public LikeDeletionException() {
+		super(LikeErrorCode.LIKE_DELETION);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/exception/LikeErrorCode.java
@@ -1,0 +1,36 @@
+package com.example.junggoheaven.domain.like.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.junggoheaven.global.common.exception.ErrorCode;
+
+public enum LikeErrorCode implements ErrorCode {
+	ALREADY_LIKES("ALREADY_LIKES", HttpStatus.BAD_REQUEST, "이미 좋아요 누른 상품 입니다."),
+	INVALID_LIKES("INVALID_LIKES", HttpStatus.BAD_REQUEST, "유효하지 않은 좋아요 입니다."),
+	LIKE_DELETION("LIKE_DELETION", HttpStatus.FORBIDDEN, "내가 누른 좋아요만 삭제 가능합니다.");
+
+	String code;
+	HttpStatus httpStatus;
+	String message;
+
+	LikeErrorCode(String code, HttpStatus httpStatus, String message) {
+		this.code = code;
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+
+	@Override
+	public String getCode() {
+		return this.code;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return this.httpStatus;
+	}
+
+	@Override
+	public String getDefaultMessage() {
+		return this.message;
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/exception/LikeException.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/exception/LikeException.java
@@ -1,0 +1,10 @@
+package com.example.junggoheaven.domain.like.exception;
+
+import com.example.junggoheaven.global.common.exception.BaseException;
+import com.example.junggoheaven.global.common.exception.ErrorCode;
+
+public class LikeException extends BaseException {
+	public LikeException(LikeErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/repository/LikeCustomRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/repository/LikeCustomRepository.java
@@ -1,0 +1,9 @@
+package com.example.junggoheaven.domain.like.repository;
+
+import java.util.List;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+
+public interface LikeCustomRepository {
+	List<Like> findTop5Likes();
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/repository/LikeCustomRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/repository/LikeCustomRepository.java
@@ -5,5 +5,5 @@ import java.util.List;
 import com.example.junggoheaven.domain.like.entity.Like;
 
 public interface LikeCustomRepository {
-	List<Like> findTop5Likes();
+	List<Long> findTop5Likes();
 }

--- a/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepository.java
@@ -1,6 +1,5 @@
 package com.example.junggoheaven.domain.like.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -13,14 +12,15 @@ import com.example.junggoheaven.domain.like.entity.Like;
 
 public interface LikeRepository extends JpaRepository<Like, Long>, LikeCustomRepository {
 
-	int countByProduct_Id(Long productId);
+	@Query("SELECT COUNT(l) FROM Like l GROUP BY l.product.id HAVING l.product.id = :productId")
+	int countByProductId(Long productId);
 
 	@EntityGraph(attributePaths = {"product"})
 	@Query("SELECT l FROM Like l WHERE l.user.id = :userId AND l.product.deletedAt IS NULL")
 	Page<Like> findByUserAndValidProductOrderByIdAsc(Long userId, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"product"})
-	@Query("SELECT l FROM Like l WHERE l.product.id = :productId AND l.product.deletedAt IS NULL")
+	@Query("SELECT l.product FROM Like l WHERE l.product.id = :productId AND l.product.deletedAt IS NULL")
 	Like findByValidProductId(Long productId);
 
 	@Query("SELECT l FROM Like l WHERE l.id = :likeId AND l.product.deletedAt IS NULL")

--- a/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepository.java
@@ -1,0 +1,28 @@
+package com.example.junggoheaven.domain.like.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+
+public interface LikeRepository extends JpaRepository<Like, Long>, LikeCustomRepository {
+
+	int countByProduct_Id(Long productId);
+
+	@EntityGraph(attributePaths = {"product"})
+	@Query("SELECT l FROM Like l WHERE l.user.id = :userId AND l.product.deletedAt IS NULL")
+	Page<Like> findByUserAndValidProductOrderByIdAsc(Long userId, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"product"})
+	@Query("SELECT l FROM Like l WHERE l.product.id = :productId AND l.product.deletedAt IS NULL")
+	Like findByValidProductId(Long productId);
+
+	@Query("SELECT l FROM Like l WHERE l.id = :likeId AND l.product.deletedAt IS NULL")
+	Optional<Like> findValidById(Long likeId);
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.example.junggoheaven.domain.like.repository;
+
+import static com.example.junggoheaven.domain.like.entity.QLike.*;
+import static com.example.junggoheaven.domain.product.entity.QProduct.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<Like> findTop5Likes() {
+		LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+
+		List<Long> top5 = jpaQueryFactory
+			.select(like.product.id)
+			.from(like)
+			.join(like.product, product)
+			.where(product.createdAt.after(sevenDaysAgo)
+				.and(product.deletedAt.isNull()))
+			.groupBy(like.product.id)
+			.orderBy(like.product.count().desc())
+			.limit(5)
+			.fetch();
+
+		return jpaQueryFactory
+			.selectFrom(like)
+			.join(like.product, product).fetchJoin()
+			.where(like.product.id.in(top5))
+			.fetch();
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/repository/LikeRepositoryImpl.java
@@ -20,9 +20,10 @@ public class LikeRepositoryImpl implements LikeCustomRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<Like> findTop5Likes() {
+	public List<Long> findTop5Likes() {
 		LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
 
+		// 좋아요 Top5인 product.id List를 구함
 		List<Long> top5 = jpaQueryFactory
 			.select(like.product.id)
 			.from(like)
@@ -34,10 +35,6 @@ public class LikeRepositoryImpl implements LikeCustomRepository {
 			.limit(5)
 			.fetch();
 
-		return jpaQueryFactory
-			.selectFrom(like)
-			.join(like.product, product).fetchJoin()
-			.where(like.product.id.in(top5))
-			.fetch();
+		return top5;
 	}
 }

--- a/src/main/java/com/example/junggoheaven/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/LikeService.java
@@ -57,13 +57,14 @@ public class LikeService {
 
 	public LikeResponseDto getProductLikes(Long productId) {
 		int count = likeFinder.getProductLikesCount(productId);
-		Like like = likeFinder.getProductById(productId);
+		Like like = likeFinder.getLikeByProductId(productId);
 		return LikeResponseDto.from(like, count);
 	}
 
 	public List<LikeProductResponseDto> getPopularProducts() {
-		List<Like> top5 = likeFinder.getProductLikesTop5();
-		return top5.stream().map(LikeProductResponseDto::from).toList();
+		List<Long> top5ProductIds = likeFinder.getProductLikesTop5();
+		List<Product> products = productFinder.findLikeTop5Products(top5ProductIds);
+		return products.stream().map(LikeProductResponseDto::from).toList();
 	}
 
 	public void deleteProductLikes(Long userId, Long likeId) {

--- a/src/main/java/com/example/junggoheaven/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/LikeService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.junggoheaven.domain.like.dto.LikeProductResponseDto;
 import com.example.junggoheaven.domain.like.dto.LikeRequestDto;
@@ -57,8 +58,8 @@ public class LikeService {
 
 	public LikeResponseDto getProductLikes(Long productId) {
 		int count = likeFinder.getProductLikesCount(productId);
-		Like like = likeFinder.getLikeByProductId(productId);
-		return LikeResponseDto.from(like, count);
+		Product product = productFinder.findProductById(productId);
+		return LikeResponseDto.from(product, count);
 	}
 
 	public List<LikeProductResponseDto> getPopularProducts() {

--- a/src/main/java/com/example/junggoheaven/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/LikeService.java
@@ -1,0 +1,84 @@
+package com.example.junggoheaven.domain.like.service;
+
+import java.util.List;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.example.junggoheaven.domain.like.dto.LikeProductResponseDto;
+import com.example.junggoheaven.domain.like.dto.LikeRequestDto;
+import com.example.junggoheaven.domain.like.dto.LikeResponseDto;
+import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.like.exception.AlreadyLikesException;
+import com.example.junggoheaven.domain.like.exception.LikeDeletionException;
+import com.example.junggoheaven.domain.like.service.component.LikeFinder;
+import com.example.junggoheaven.domain.like.service.component.LikeWriter;
+import com.example.junggoheaven.domain.product.entity.Product;
+import com.example.junggoheaven.domain.product.repository.ProductRepository;
+import com.example.junggoheaven.domain.product.service.component.ProductFinder;
+import com.example.junggoheaven.domain.user.entity.User;
+import com.example.junggoheaven.domain.user.service.component.UserFinder;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+	private final ProductFinder productFinder;
+	private final UserFinder userFinder;
+	private final LikeFinder likeFinder;
+	private final LikeWriter likeWriter;
+
+	public LikeResponseDto createLike(Long userId, LikeRequestDto requestDto) {
+		User user = userFinder.findValidUserById(userId);
+		Long productId = requestDto.getProductId();
+		Product product = productFinder.findProductById(productId);
+
+		Like newLike = new Like(product, user);
+		try {
+			likeWriter.saveLike(newLike);
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyLikesException();
+		}
+
+		int count = likeFinder.getProductLikesCount(productId);
+		return LikeResponseDto.from(newLike, count);
+	}
+
+	public Page<LikeProductResponseDto> getMyLikeProducts(Long userId, int pageNumber, int pageSize) {
+		Pageable pageable = PageRequest.of(pageNumber, pageSize);
+		Page<Like> userLikes = likeFinder.getUserLikes(userId, pageable);
+		return userLikes.map(LikeProductResponseDto::from);
+	}
+
+	public LikeResponseDto getProductLikes(Long productId) {
+		int count = likeFinder.getProductLikesCount(productId);
+		Like like = likeFinder.getProductById(productId);
+		return LikeResponseDto.from(like, count);
+	}
+
+	public List<LikeProductResponseDto> getPopularProducts() {
+		List<Like> top5 = likeFinder.getProductLikesTop5();
+		return top5.stream().map(LikeProductResponseDto::from).toList();
+	}
+
+	public void deleteProductLikes(Long userId, Long likeId) {
+		User user = userFinder.findValidUserById(userId);
+		Like like = likeFinder.getLike(likeId);
+
+		if (!like.getUser().equals(user)) {
+			throw new LikeDeletionException();
+		}
+
+		likeWriter.deleteLike(like);
+	}
+
+	public Page<LikeProductResponseDto> getProductsOfUser(Long userId, int pageNumber, int pageSize) {
+		Pageable pageable = PageRequest.of(pageNumber, pageSize);
+		return likeFinder.getUserLikes(userId, pageable).map(LikeProductResponseDto::from);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeFinder.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeFinder.java
@@ -1,0 +1,42 @@
+package com.example.junggoheaven.domain.like.service.component;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.like.exception.InvalidLikesException;
+import com.example.junggoheaven.domain.like.repository.LikeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LikeFinder {
+
+	private final LikeRepository likeRepository;
+
+	public int getProductLikesCount(Long productId) {
+		return likeRepository.countByProduct_Id(productId);
+	}
+
+	public Page<Like> getUserLikes(Long userId, Pageable pageable) {
+		return likeRepository.findByUserAndValidProductOrderByIdAsc(userId, pageable);
+	}
+
+	public Like getProductById(Long productId) {
+		return likeRepository.findByValidProductId(productId);
+	}
+
+	public List<Like> getProductLikesTop5() {
+		return likeRepository.findTop5Likes();
+	}
+
+	public Like getLike(Long likeId) {
+		return likeRepository.findValidById(likeId).orElseThrow(InvalidLikesException::new);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeFinder.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeFinder.java
@@ -28,11 +28,11 @@ public class LikeFinder {
 		return likeRepository.findByUserAndValidProductOrderByIdAsc(userId, pageable);
 	}
 
-	public Like getProductById(Long productId) {
+	public Like getLikeByProductId(Long productId) {
 		return likeRepository.findByValidProductId(productId);
 	}
 
-	public List<Like> getProductLikesTop5() {
+	public List<Long> getProductLikesTop5() {
 		return likeRepository.findTop5Likes();
 	}
 

--- a/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeFinder.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeFinder.java
@@ -21,7 +21,7 @@ public class LikeFinder {
 	private final LikeRepository likeRepository;
 
 	public int getProductLikesCount(Long productId) {
-		return likeRepository.countByProduct_Id(productId);
+		return likeRepository.countByProductId(productId);
 	}
 
 	public Page<Like> getUserLikes(Long userId, Pageable pageable) {

--- a/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeWriter.java
+++ b/src/main/java/com/example/junggoheaven/domain/like/service/component/LikeWriter.java
@@ -1,0 +1,23 @@
+package com.example.junggoheaven.domain.like.service.component;
+
+import org.springframework.stereotype.Service;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.like.repository.LikeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LikeWriter {
+
+	private final LikeRepository likeRepository;
+
+	public Like saveLike(Like like){
+		return likeRepository.save(like);
+	}
+
+	public void deleteLike(Like like){
+		likeRepository.delete(like);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/product/repository/ProductRepository.java
@@ -1,5 +1,8 @@
 package com.example.junggoheaven.domain.product.repository;
 
+import java.util.Collection;
+import java.util.List;
+
 import com.example.junggoheaven.domain.product.entity.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,5 +12,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
 	Page<Product> findByDeletedAtNull(Pageable pageable); // deleteAt이 null 인 즉 product 값이 존재하는경우
 
-
+	List<Product> findByIdIn(Collection<Long> ids);
 }

--- a/src/main/java/com/example/junggoheaven/domain/product/service/component/ProductFinder.java
+++ b/src/main/java/com/example/junggoheaven/domain/product/service/component/ProductFinder.java
@@ -3,6 +3,8 @@ package com.example.junggoheaven.domain.product.service.component;
 import com.example.junggoheaven.domain.product.entity.Product;
 import com.example.junggoheaven.domain.product.exception.ProductNotFoundException;
 import com.example.junggoheaven.domain.product.repository.ProductRepository;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,5 +30,7 @@ public class ProductFinder {
 			.orElseThrow(ProductNotFoundException::new);
 	}
 
-
+	public List<Product> findLikeTop5Products(List<Long> ids){
+		return productRepository.findByIdIn(ids);
+	}
 }

--- a/src/test/java/com/example/junggoheaven/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/like/service/LikeServiceTest.java
@@ -110,7 +110,7 @@ class LikeServiceTest {
 	@Test
 	void getProductLikes() {
 		given(likeFinder.getProductLikesCount(any())).willReturn(3);
-		given(likeFinder.getLikeByProductId(any())).willReturn(like);
+		given(productFinder.findProductById(any())).willReturn(product);
 
 		LikeResponseDto responseDto = likeService.getProductLikes(11L);
 
@@ -124,7 +124,7 @@ class LikeServiceTest {
 		List<Long> ids = List.of(10L);
 		given(likeFinder.getProductLikesTop5()).willReturn(ids);
 		given(productFinder.findLikeTop5Products(any())).willReturn(List.of(product));
-		
+
 		List<LikeProductResponseDto> responseDto = likeService.getPopularProducts();
 
 		assertThat(responseDto).isNotNull();

--- a/src/test/java/com/example/junggoheaven/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/like/service/LikeServiceTest.java
@@ -110,7 +110,7 @@ class LikeServiceTest {
 	@Test
 	void getProductLikes() {
 		given(likeFinder.getProductLikesCount(any())).willReturn(3);
-		given(likeFinder.getProductById(any())).willReturn(like);
+		given(likeFinder.getLikeByProductId(any())).willReturn(like);
 
 		LikeResponseDto responseDto = likeService.getProductLikes(11L);
 
@@ -121,9 +121,12 @@ class LikeServiceTest {
 
 	@Test
 	void getPopularProducts() {
-		List<Like> top5 = List.of(like);
-		given(likeFinder.getProductLikesTop5()).willReturn(top5);
+		List<Long> ids = List.of(10L);
+		given(likeFinder.getProductLikesTop5()).willReturn(ids);
+		given(productFinder.findLikeTop5Products(any())).willReturn(List.of(product));
+		
 		List<LikeProductResponseDto> responseDto = likeService.getPopularProducts();
+
 		assertThat(responseDto).isNotNull();
 		assertThat(responseDto.get(0).getProductId()).isEqualTo(product.getId());
 	}

--- a/src/test/java/com/example/junggoheaven/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/like/service/LikeServiceTest.java
@@ -1,0 +1,163 @@
+package com.example.junggoheaven.domain.like.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.junggoheaven.domain.like.dto.LikeProductResponseDto;
+import com.example.junggoheaven.domain.like.dto.LikeRequestDto;
+import com.example.junggoheaven.domain.like.dto.LikeResponseDto;
+import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.like.exception.AlreadyLikesException;
+import com.example.junggoheaven.domain.like.exception.LikeDeletionException;
+import com.example.junggoheaven.domain.like.service.component.LikeFinder;
+import com.example.junggoheaven.domain.like.service.component.LikeWriter;
+import com.example.junggoheaven.domain.product.entity.Product;
+import com.example.junggoheaven.domain.product.repository.ProductRepository;
+import com.example.junggoheaven.domain.product.service.component.ProductFinder;
+import com.example.junggoheaven.domain.user.entity.User;
+import com.example.junggoheaven.domain.user.service.component.UserFinder;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+	@InjectMocks
+	private LikeService likeService;
+
+	@Mock
+	private UserFinder userFinder;
+	@Mock
+	private ProductFinder productFinder;
+	@Mock
+	private LikeFinder likeFinder;
+	@Mock
+	private LikeWriter likeWriter;
+
+	User user;
+	Product product;
+	Like like;
+
+	@BeforeEach
+	void setUp() {
+		user = new User("email", "password", "name", "010-0000-0001", "address");
+		ReflectionTestUtils.setField(user, "id", 1L);
+		ReflectionTestUtils.setField(user, "createdAt", LocalDateTime.of(2024,12,31,12,0,0));
+		ReflectionTestUtils.setField(user, "modifiedAt", LocalDateTime.of(2024,12,31,12,0,0));
+
+		product = new Product(user, "product", "description", 13000L);
+		ReflectionTestUtils.setField(product, "id", 11L);
+		ReflectionTestUtils.setField(product, "createdAt", LocalDateTime.of(2025,1,31,12,0,0));
+		ReflectionTestUtils.setField(product, "modifiedAt", LocalDateTime.of(2025,1,31,12,0,0));
+
+		like = new Like(product, user);
+		ReflectionTestUtils.setField(like, "id", 111L);
+	}
+
+	@Test
+	void createLike() {
+		LikeRequestDto requestDto = new  LikeRequestDto(11L);
+
+		given(userFinder.findValidUserById(any())).willReturn(user);
+		given(productFinder.findProductById(any())).willReturn(product);
+		given(likeFinder.getProductLikesCount(any())).willReturn(3);
+
+		LikeResponseDto responseDto = likeService.createLike(1L, requestDto);
+
+		assertThat(responseDto).isNotNull();
+		assertThat(responseDto.getProductId()).isEqualTo(product.getId());
+	}
+
+	@Test
+	void createLike_unique_중복_에러_발생() {
+		LikeRequestDto requestDto = new  LikeRequestDto(11L);
+
+		given(userFinder.findValidUserById(any())).willReturn(user);
+		given(productFinder.findProductById(any())).willReturn(product);
+		given(likeWriter.saveLike(any())).willThrow(DataIntegrityViolationException.class);
+
+		assertThrows(AlreadyLikesException.class, () ->{
+			likeService.createLike(1L, requestDto);
+		});
+	}
+
+	@Test
+	void getMyLikeProducts() {
+		Page<Like> page = new PageImpl<>(List.of(like));
+		given(likeFinder.getUserLikes(any(), any())).willReturn(page);
+		Page<LikeProductResponseDto> responseDto = likeService.getMyLikeProducts(1L, 1, 5);
+
+		assertThat(responseDto).isNotNull();
+		assertThat(responseDto.getTotalElements()).isEqualTo(1);
+		assertThat(responseDto.getContent().get(0).getProductId()).isEqualTo(product.getId());
+	}
+
+	@Test
+	void getProductLikes() {
+		given(likeFinder.getProductLikesCount(any())).willReturn(3);
+		given(likeFinder.getProductById(any())).willReturn(like);
+
+		LikeResponseDto responseDto = likeService.getProductLikes(11L);
+
+		assertThat(responseDto).isNotNull();
+		assertThat(responseDto.getProductId()).isEqualTo(product.getId());
+		assertThat(responseDto.getCount()).isEqualTo(3);
+	}
+
+	@Test
+	void getPopularProducts() {
+		List<Like> top5 = List.of(like);
+		given(likeFinder.getProductLikesTop5()).willReturn(top5);
+		List<LikeProductResponseDto> responseDto = likeService.getPopularProducts();
+		assertThat(responseDto).isNotNull();
+		assertThat(responseDto.get(0).getProductId()).isEqualTo(product.getId());
+	}
+
+	@Test
+	void deleteProductLikes() {
+		given(userFinder.findValidUserById(any())).willReturn(user);
+		given(likeFinder.getLike(any())).willReturn(like);
+
+		likeService.deleteProductLikes(1L, 111L);
+
+		assertThat(like.getUser()).isEqualTo(user);
+	}
+
+	@Test
+	void deleteProductLikes_사용자_불일치() {
+		User otheruser = new User("email", "password", "name", "010-0000-0001", "address");
+		given(userFinder.findValidUserById(any())).willReturn(otheruser);
+		given(likeFinder.getLike(any())).willReturn(like);
+
+		assertThat(like.getUser()).isNotEqualTo(otheruser);
+		assertThrows(LikeDeletionException.class, () ->{
+			likeService.deleteProductLikes(1L, 111L);
+		});
+	}
+
+	@Test
+	void getProductsOfUser() {
+		Page<Like> page = new PageImpl<>(List.of(like));
+		given(likeFinder.getUserLikes(any(), any())).willReturn(page);
+
+		Page<LikeProductResponseDto> responseDto = likeService.getProductsOfUser(1L, 0, 5);
+
+		assertThat(responseDto).isNotNull();
+		assertThat(responseDto.getTotalElements()).isEqualTo(1);
+	}
+}

--- a/src/test/java/com/example/junggoheaven/domain/like/service/component/LikeFinderTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/like/service/component/LikeFinderTest.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.example.junggoheaven.domain.like.entity.Like;
@@ -56,7 +55,7 @@ class LikeFinderTest {
 	@Test
 	void getProductLikesCount() {
 		int count = 5;
-		given(likeRepository.countByProduct_Id(1L)).willReturn(count);
+		given(likeRepository.countByProductId(1L)).willReturn(count);
 		int result = likeFinder.getProductLikesCount(1L);
 		assertThat(result).isEqualTo(count);
 	}

--- a/src/test/java/com/example/junggoheaven/domain/like/service/component/LikeFinderTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/like/service/component/LikeFinderTest.java
@@ -1,0 +1,109 @@
+package com.example.junggoheaven.domain.like.service.component;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.junggoheaven.domain.like.entity.Like;
+import com.example.junggoheaven.domain.like.exception.InvalidLikesException;
+import com.example.junggoheaven.domain.like.repository.LikeRepository;
+import com.example.junggoheaven.domain.product.entity.Product;
+import com.example.junggoheaven.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class LikeFinderTest {
+
+	@InjectMocks
+	private LikeFinder likeFinder;
+	@Mock
+	private LikeRepository likeRepository;
+
+	Like one;
+	Like two;
+	Product product;
+	User user;
+
+	@BeforeEach
+	void setUp() {
+		user = new User("emali", "name","010-1234-1234");
+		ReflectionTestUtils.setField(user, "id", 1L);
+
+		product = new Product(user, "product", "information", 13000L);
+		ReflectionTestUtils.setField(product, "id", 10L);
+
+		one = new Like(product, user);
+		two = new Like(product, user);
+		ReflectionTestUtils.setField(one, "id", 11L);
+		ReflectionTestUtils.setField(two, "id", 12L);
+	}
+
+	@Test
+	void getProductLikesCount() {
+		int count = 5;
+		given(likeRepository.countByProduct_Id(1L)).willReturn(count);
+		int result = likeFinder.getProductLikesCount(1L);
+		assertThat(result).isEqualTo(count);
+	}
+
+	@Test
+	void getUserLikes() {
+		Pageable pageable = PageRequest.of(0, 10);
+		Page<Like> page = new PageImpl<>(List.of(one, two));
+		given(likeRepository.findByUserAndValidProductOrderByIdAsc(any(), any())).willReturn(page);
+
+		Page<Like> userLikes = likeFinder.getUserLikes(1L, pageable);
+
+		assertThat(userLikes).isNotNull();
+		assertThat(userLikes.getTotalElements()).isEqualTo(2);
+		assertThat(userLikes.getContent().get(0)).isEqualTo(one);
+	}
+
+	@Test
+	void getLikeByProductId() {
+		given(likeRepository.findByValidProductId(any())).willReturn(one);
+		Like result = likeFinder.getLikeByProductId(11L);
+		assertThat(result).isEqualTo(one);
+		assertThat(result.getProduct()).isEqualTo(product);
+	}
+
+	@Test
+	void getProductLikesTop5() {
+		List<Long> list = List.of(product.getId());
+		given(likeRepository.findTop5Likes()).willReturn(list);
+
+		List<Long> ids = likeFinder.getProductLikesTop5();
+
+		assertThat(ids).isNotNull();
+		assertThat(ids.get(0)).isEqualTo(product.getId());
+	}
+
+	@Test
+	void getLike() {
+		given(likeRepository.findValidById(1L)).willReturn(Optional.of(one));
+		given(likeRepository.findValidById(2L)).willReturn(Optional.empty());
+
+		Like result = likeFinder.getLike(1L);
+		assertThat(result).isNotNull();
+		assertThat(result.getProduct()).isEqualTo(product);
+
+		assertThrows(InvalidLikesException.class, () -> {
+			likeFinder.getLike(2L);
+		});
+	}
+}


### PR DESCRIPTION
## 기본 기능

1. createLike: 사용자가 상품에 좋아요 등록
2. getMyLikeProducts: 내가 좋아요를 누른 상품 목록 조회
3. getProductLikes: 상품에 눌린 좋아요 수 조회
4. getPopularProducts: 가장 좋아요가 많이 눌린 Top5 상품 조회
5. deleteProductLikes: 상품에 누른 좋아요 해제
6. getProductsOfUser: 특정 사용자가 누른 좋아요 목록 조회(ADMIN)




## Product 변경안

1. `likeFinder.getProductLikesTop5()`: product.id를 group으로 묶고, count기준으로 내림차순 desc
2.  limit을 5로 지정하여 상위 5개의 product id만 List로 뽑아낸다.
3. **`productFinder.findLikeTop5Products(List<Long> ids)`**: in을 이용해 product id가 ids에 일치하는 것만 가져와 List<Product> 생성
4. LikeProductResponseDto의 from의 파라미터로 Product를 받을 수 있게 하여, List<Product>를 List<Dto>로 변환