### PR TITLE
Feat/product 이미지 null 임시 등록 기능 및 @Valid 추가 

### DIFF
--- a/src/main/java/com/example/junggoheaven/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/junggoheaven/domain/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.example.junggoheaven.domain.product.dto.response.ProductResponseDto;
 import com.example.junggoheaven.domain.product.service.ProductService;
 import com.example.junggoheaven.global.auth.dto.user.AuthUser;
 import com.example.junggoheaven.global.common.response.ResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -37,7 +38,7 @@ public class ProductController {
 	@PostMapping("/v1/products")
 	public ResponseDto<ProductResponseDto> saveProduct(
 		@AuthenticationPrincipal AuthUser authUser,
-		@RequestBody ProductRequestDto productRequestDto
+		@Valid @RequestBody ProductRequestDto productRequestDto
 	) {
 		ProductResponseDto productResponseDto = productService.saveProduct(authUser, productRequestDto);
 
@@ -94,7 +95,7 @@ public class ProductController {
 	public ResponseDto<ProductResponseDto> editProduct(
 		@AuthenticationPrincipal AuthUser authUser,
 		@PathVariable("productId") Long productId,
-		@RequestBody ProductRequestDto productRequestDto
+		@Valid @RequestBody ProductRequestDto productRequestDto
 	) {
 		ProductResponseDto productResponseDto = productService.editProduct(authUser, productId, productRequestDto);
 
@@ -110,7 +111,7 @@ public class ProductController {
 	public ResponseDto<ProductResponseDto> setSellStatus(
 		@AuthenticationPrincipal AuthUser authUser,
 		@PathVariable("productId") Long productId,
-		@RequestBody ProductSellStatusRequestDto productSellStatusRequestDto
+		@Valid @RequestBody ProductSellStatusRequestDto productSellStatusRequestDto
 	) {
 		ProductResponseDto productResponseDto = productService.setSellStatus(authUser, productId,
 			productSellStatusRequestDto);

--- a/src/main/java/com/example/junggoheaven/domain/product/dto/request/ProductRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/product/dto/request/ProductRequestDto.java
@@ -1,6 +1,9 @@
 package com.example.junggoheaven.domain.product.dto.request;
 
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,10 +11,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ProductRequestDto {
 
+	@NotBlank(message = "상품 이름을 입력해 주세요")
+	@Size(min = 2, max = 30, message = "상품 이름은 최소 2자에서 최대 30자 사이입니다.")
 	private final String name;
 
+	@NotBlank(message = "상품 정보를 입력해 주세요")
+	@Size(min = 5, max = 2000, message = "상품 정보는 최소 5자에서 최대 2000자 사이입니다.")
 	private final String information;
 
+	@NotNull(message = "가격을 입력해 주세요")
 	private final Long price;
 
 	private final Long productImageId;

--- a/src/main/java/com/example/junggoheaven/domain/product/dto/request/ProductSellStatusRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/product/dto/request/ProductSellStatusRequestDto.java
@@ -2,6 +2,7 @@ package com.example.junggoheaven.domain.product.dto.request;
 
 
 import com.example.junggoheaven.domain.product.enums.SellStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,6 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ProductSellStatusRequestDto {
 
+	@NotNull(message = "판매상태를 선택해 주세요")
 	private final SellStatus sellStatus;
 
 }

--- a/src/main/java/com/example/junggoheaven/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/junggoheaven/domain/product/service/ProductService.java
@@ -53,6 +53,24 @@ public class ProductService {
 
 		User user = userFinder.findByUserId(authUser.getId());
 
+		if(productRequestDto.getProductImageId() == null){
+
+			Product product = new Product(
+				user,
+				productRequestDto.getName(),
+				productRequestDto.getInformation(),
+				productRequestDto.getPrice(),
+				null
+			);
+
+			productWriter.saveProduct(product);
+			eventPublisher.publishEventAfterTransaction(new ProductRegisteredEvent(this, user.getId(), product.getName()));
+
+			return new ProductResponseDto(product);
+
+		}
+
+
 		ProductImage productImage = productImageRepository.findById(productRequestDto.getProductImageId())
 			.orElseThrow(UnexpectedErrorException::new);
 


### PR DESCRIPTION
## 📌 PR 요약
- 상품게시물 등록시 상품이미지를 null로 등록하는 임시 기능
- Dto와 Controller에 @Valid 추가

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - 해당 없음

## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
- api/v1/products

## 📸 스크린샷 (선택)

![스크린샷 2025-04-21 08-48-41](https://github.com/user-attachments/assets/ec0b035b-5ce7-46fd-9d59-a774cad4abde)
product_images_id 값에 null이 등록이 가능합니다.

![image](https://github.com/user-attachments/assets/50270795-00c5-4f4e-bc4e-f838728bd44b)
현재 이미지 null 등록을 위해 ProductReqeustDto의 이미지 부분은 따로 검증 기능을 추가하지 않았습니다.

![image](https://github.com/user-attachments/assets/494c08f5-df9d-4a42-bbb2-85d3d0a172d2)
ProductRequestDto에 비정상값을 넣으면 검증부분에서 걸립니다.

## ⚠️ 주의 사항 (선택)
리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.
이미지 null값 등록은 임시 기능입니다. deprecated 될수있습니다.


## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.