### PR TITLE
Feat/image

### DIFF
--- a/src/main/java/com/example/junggoheaven/domain/image/service/ChatRoomImageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/ChatRoomImageService.java
@@ -52,14 +52,12 @@ public class ChatRoomImageService {
             String imageUrl = uploadUrls.get(i);
             String originalFilename = originalFiles.get(i).getOriginalFilename();
 
-            String fullUrl = s3StorageService.buildCloudFrontUrl(imageUrl);
-
             RedisChatMessageDto redisDto = new RedisChatMessageDto(
                     chatRoom.getId(),
                     user.getId(),
                     IdGenerator.generateId(),
                     null,  // 텍스트 메시지는 없음
-                    fullUrl,
+                    imageUrl,
                     originalFilename,
                     MessageType.IMAGE
             );
@@ -70,7 +68,7 @@ public class ChatRoomImageService {
                     redisDto.getChatMessageId(),
                     redisDto.getSenderId(),
                     redisDto.getMessage(),
-                    fullUrl,
+                    imageUrl,
                     redisDto.getSendAt(),
                     redisDto.getMessageType(),
                     false

--- a/src/main/java/com/example/junggoheaven/domain/image/service/ChatRoomImageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/ChatRoomImageService.java
@@ -52,7 +52,7 @@ public class ChatRoomImageService {
             String imageUrl = uploadUrls.get(i);
             String originalFilename = originalFiles.get(i).getOriginalFilename();
 
-            String fullUrl = s3StorageService.buildS3Url(imageUrl);
+            String fullUrl = s3StorageService.buildCloudFrontUrl(imageUrl);
 
             RedisChatMessageDto redisDto = new RedisChatMessageDto(
                     chatRoom.getId(),

--- a/src/main/java/com/example/junggoheaven/domain/image/service/ProductImageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/ProductImageService.java
@@ -31,9 +31,7 @@ public class ProductImageService {
             String imageUrl = uploadUrls.get(i);
             String originalFilename = originalFiles.get(i).getOriginalFilename();
 
-            String fullUrl = s3StorageService.buildCloudFrontUrl(imageUrl);
-
-            ProductImage productImage = ProductImage.of(fullUrl, originalFilename);
+            ProductImage productImage = ProductImage.of(imageUrl, originalFilename);
             productImages.add(productImage);
         }
         productImageRepository.saveAll(productImages);

--- a/src/main/java/com/example/junggoheaven/domain/image/service/ProductImageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/ProductImageService.java
@@ -31,7 +31,7 @@ public class ProductImageService {
             String imageUrl = uploadUrls.get(i);
             String originalFilename = originalFiles.get(i).getOriginalFilename();
 
-            String fullUrl = s3StorageService.buildS3Url(imageUrl);
+            String fullUrl = s3StorageService.buildCloudFrontUrl(imageUrl);
 
             ProductImage productImage = ProductImage.of(fullUrl, originalFilename);
             productImages.add(productImage);

--- a/src/main/java/com/example/junggoheaven/domain/image/service/ProfileImageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/ProfileImageService.java
@@ -30,3 +30,4 @@ public class ProfileImageService {
         return profileImageRepository.save(profileImage);
     }
 }
+

--- a/src/main/java/com/example/junggoheaven/domain/image/service/ProfileImageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/ProfileImageService.java
@@ -4,8 +4,6 @@ import com.example.junggoheaven.domain.image.dto.UploadResponse;
 import com.example.junggoheaven.domain.image.entity.ProfileImage;
 import com.example.junggoheaven.domain.image.repository.ProfileImageRepository;
 import com.example.junggoheaven.domain.image.service.S3.S3StorageService;
-import com.example.junggoheaven.domain.user.entity.User;
-import com.example.junggoheaven.domain.user.service.component.UserFinder;
 import com.example.junggoheaven.global.auth.dto.user.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,18 +17,14 @@ public class ProfileImageService {
 
     private final ProfileImageRepository profileImageRepository;
     private final S3StorageService s3StorageService;
-    private final UserFinder userFinder;
 
-    @Value("${spring.cloud.aws.s3.bucket}")
-    private String bucket;
-
-    @Value("${spring.cloud.aws.region.static}")
-    private String region;
+    @Value("${cloudfront.domain}")
+    private String cloudFrontDomain;
 
     @Transactional
     public ProfileImage uploadProfileImage(MultipartFile image, AuthUser authUser, Long userId) {
         UploadResponse uploadResponse = s3StorageService.upload(image, "profiles", authUser, userId);
-        String profileImageUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + uploadResponse.getUploadUrl();
+        String profileImageUrl = "https://" + cloudFrontDomain + "/" + uploadResponse.getUploadUrl();
 
         ProfileImage profileImage = ProfileImage.of(image.getOriginalFilename(), profileImageUrl);
         return profileImageRepository.save(profileImage);

--- a/src/main/java/com/example/junggoheaven/domain/image/service/S3/S3StorageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/S3/S3StorageService.java
@@ -132,7 +132,9 @@ public class S3StorageService implements StorageService {
             try {
                 counter++;
                 UploadResponse upload = upload(image, type, authUser, resourceId);
-                responses.add(upload.getUploadUrl());
+                String fullUrl = buildCloudFrontUrl(upload.getUploadUrl());
+                responses.add(fullUrl);
+//                responses.add(upload.getUploadUrl());
             } catch (Exception e) {
                 log.error("{} 번째 업로드 중 예외 발생: {}", counter, e.getLocalizedMessage());
                 throw new ImageUploadIOException();

--- a/src/main/java/com/example/junggoheaven/domain/image/service/S3/S3StorageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/S3/S3StorageService.java
@@ -134,7 +134,6 @@ public class S3StorageService implements StorageService {
                 UploadResponse upload = upload(image, type, authUser, resourceId);
                 String fullUrl = buildCloudFrontUrl(upload.getUploadUrl());
                 responses.add(fullUrl);
-//                responses.add(upload.getUploadUrl());
             } catch (Exception e) {
                 log.error("{} 번째 업로드 중 예외 발생: {}", counter, e.getLocalizedMessage());
                 throw new ImageUploadIOException();

--- a/src/main/java/com/example/junggoheaven/domain/image/service/S3/S3StorageService.java
+++ b/src/main/java/com/example/junggoheaven/domain/image/service/S3/S3StorageService.java
@@ -38,6 +38,9 @@ public class S3StorageService implements StorageService {
     private final S3Client s3Client;
     private final UserFinder userFinder;
 
+    @Value("${cloudfront.domain}")
+    private String cloudFrontDomain;
+
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
@@ -68,6 +71,7 @@ public class S3StorageService implements StorageService {
                 .bucket(bucket)
                 .key(key)
                 .contentType(image.getContentType())
+                .cacheControl("public, max-age=7776000") // 캐시 3개월
                 .build();
 
         try {
@@ -138,7 +142,7 @@ public class S3StorageService implements StorageService {
     }
 
     // S3에 업로드된 객체 URL과 동일한 URL로 변경
-    public String buildS3Url(String key) {
-        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+    public String buildCloudFrontUrl(String key) {
+        return "https://" + cloudFrontDomain + "/" + key;
     }
 }

--- a/src/test/java/com/example/junggoheaven/domain/image/ProfileImageServiceTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/image/ProfileImageServiceTest.java
@@ -37,8 +37,8 @@ public class ProfileImageServiceTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(profileImageService, "bucket", "test-bucket");
-        ReflectionTestUtils.setField(profileImageService, "region", "ap-northeast-2");
+        ReflectionTestUtils.setField(profileImageService, "cloudFrontDomain", "d111111abcdef8.cloudfront.net");
+
     }
 
     @Test
@@ -49,7 +49,7 @@ public class ProfileImageServiceTest {
         );
         AuthUser authUser = new AuthUser(1L, "a@a.com", ROLE_USER, "test");
         Long userId = authUser.getId();
-        UploadResponse uploadResponse = new UploadResponse("http://testImage.com");
+        UploadResponse uploadResponse = new UploadResponse("user/1/profile.jpeg");
 
         when(s3StorageService.upload(mockMultipartFile, "profiles", authUser, userId))
                 .thenReturn(uploadResponse);


### PR DESCRIPTION
Refactor : 기존 S3에 업로드하고 S3 URL 반환  -> CloudFront URL로 접근하도록 함
CloudFront에서 이미 조회한 데이터를 3개월 간 캐싱할 수 있도록 설정

![이미지 2025  4  25  오후 3 40](https://github.com/user-attachments/assets/5b8f31d1-0245-43ba-9cbe-5c9126e8b70d)
![이미지 2025  4  25  오후 3 41](https://github.com/user-attachments/assets/fb8338f1-1ad3-43e2-b592-978cbf57e003)
![이미지 2025  4  25  오후 3 42](https://github.com/user-attachments/assets/7113d388-11bc-408c-8e7c-23c25502e60b)

아래와 같이 캐싱 되어 있으므로 사진 조회 속도가 빨라짐을 알 수 있음.