### PR TITLE
feat: OrderService 의 OrderStatus 변경시 알림 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
+    // JAVA MAIL
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -89,6 +92,8 @@ dependencies {
 
     //tsid
     implementation 'com.github.f4b6a3:tsid-creator:5.2.6'
+
+
 
 }
 

--- a/src/main/java/com/example/junggoheaven/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/controller/KeywordController.java
@@ -44,26 +44,37 @@ public class KeywordController {
 
 	@PostMapping("/v1/keywords/keyword")
 	public ResponseEntity<?> createKeyword(
-		@Valid @RequestBody CreateKeywordRequestDto dto) {
-		esKeywordService.addKeyword(dto.getUserId().toString(), dto.getKeyword());
+		@AuthenticationPrincipal AuthUser authUser,
+		@Valid @RequestBody CreateKeywordRequestDto dto
+	) {
+		esKeywordService.addKeyword(authUser.getId().toString(), dto.getKeyword());
 		return ResponseEntity.ok().build();
 	}
 
 	@PostMapping("/v1/keywords/excludeKeyword")
-	public ResponseEntity<?> createExcludeKeyword(@Valid @RequestBody CreateExcludeKeywordRequestDto dto) {
-		esKeywordService.addExcludeKeywords(dto.getUserId().toString(), dto.getKeyword(), dto.getExcludeKeyword());
+	public ResponseEntity<?> createExcludeKeyword(
+		@AuthenticationPrincipal AuthUser authUser,
+		@Valid @RequestBody CreateExcludeKeywordRequestDto dto
+	) {
+		esKeywordService.addExcludeKeywords(authUser.getId().toString(), dto.getKeyword(), dto.getExcludeKeyword());
 		return ResponseEntity.ok().build();
 	}
 
 	@DeleteMapping("/v1/keywords/keyword")
-	public ResponseEntity<?> deleteKeyword(@Valid @RequestBody DeleteKeywordRequestDto dto) {
-		esKeywordService.deleteKeyword(dto.getUserId().toString(), dto.getKeyword());
+	public ResponseEntity<?> deleteKeyword(
+		@AuthenticationPrincipal AuthUser authUser,
+		@Valid @RequestBody DeleteKeywordRequestDto dto
+	) {
+		esKeywordService.deleteKeyword(authUser.getId().toString(), dto.getKeyword());
 		return ResponseEntity.ok().build();
 	}
 
 	@DeleteMapping("/v1/keywords/excludeKeyword")
-	public ResponseEntity<?> deleteExcludeKeyword(@Valid @RequestBody DeleteExcludeKeywordRequestDto dto) {
-		esKeywordService.deleteExcludeKeyword(dto.getUserId().toString(), dto.getKeyword(), dto.getExcludeKeyword());
+	public ResponseEntity<?> deleteExcludeKeyword(
+		@AuthenticationPrincipal AuthUser authUser,
+		@Valid @RequestBody DeleteExcludeKeywordRequestDto dto
+	) {
+		esKeywordService.deleteExcludeKeyword(authUser.getId().toString(), dto.getKeyword(), dto.getExcludeKeyword());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/domain/keyword/dto/CreateExcludeKeywordRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/dto/CreateExcludeKeywordRequestDto.java
@@ -3,7 +3,6 @@ package com.example.junggoheaven.domain.keyword.dto;
 
 import org.hibernate.validator.constraints.Length;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +10,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class CreateExcludeKeywordRequestDto {
-
-	@Min(1)
-	private Long userId;
-
 	@Length(max = 10)
 	@NotBlank(message = "키워드 입력은 필수 입니다.")
 	private final String keyword;

--- a/src/main/java/com/example/junggoheaven/domain/keyword/dto/CreateKeywordRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/dto/CreateKeywordRequestDto.java
@@ -2,7 +2,6 @@ package com.example.junggoheaven.domain.keyword.dto;
 
 import org.hibernate.validator.constraints.Length;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class CreateKeywordRequestDto {
-
-	@Min(1)
-	private Long userId;
-
 	@Length(max = 10)
 	@NotBlank(message = "키워드 입력은 필수 입니다.")
 	private final String keyword;

--- a/src/main/java/com/example/junggoheaven/domain/keyword/dto/DeleteExcludeKeywordRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/dto/DeleteExcludeKeywordRequestDto.java
@@ -2,7 +2,6 @@ package com.example.junggoheaven.domain.keyword.dto;
 
 import org.hibernate.validator.constraints.Length;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class DeleteExcludeKeywordRequestDto {
-	@Min(1)
-	private Long userId;
-
 	@Length(max = 10)
 	@NotBlank(message = "키워드 입력은 필수 입니다.")
 	private final String keyword;

--- a/src/main/java/com/example/junggoheaven/domain/keyword/dto/DeleteKeywordRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/dto/DeleteKeywordRequestDto.java
@@ -2,7 +2,6 @@ package com.example.junggoheaven.domain.keyword.dto;
 
 import org.hibernate.validator.constraints.Length;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class DeleteKeywordRequestDto {
-
-	@Min(1)
-	private Long userId;
-
 	@Length(max = 10)
 	@NotBlank(message = "키워드 입력은 필수 입니다.")
 	private final String keyword;

--- a/src/main/java/com/example/junggoheaven/domain/keyword/entity/KeywordDocument.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/entity/KeywordDocument.java
@@ -8,6 +8,7 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
 
 import com.example.junggoheaven.domain.user.entity.User;
 import com.example.junggoheaven.global.message.enums.ChannelType;
@@ -19,7 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Document(indexName = "keyword")
+@Document(indexName = "keyword", writeTypeHint = WriteTypeHint.FALSE)
 @Setting
 @Mapping(mappingPath = "elastic/keyword-mapping.json")
 @NoArgsConstructor
@@ -36,9 +37,8 @@ public class KeywordDocument {
 	@Field(type = FieldType.Nested)
 	private List<Keyword> keywords = new ArrayList<>();
 
-	@Enumerated(EnumType.STRING)
-	@Field(type = FieldType.Keyword)
-	private List<ChannelType> channels = new ArrayList<> ();
+	@Field(type = FieldType.Object)
+	private List<Channel> channels = new ArrayList<> ();
 
 	private KeywordDocument(String id, String email) {
 		this.id = id;
@@ -57,12 +57,13 @@ public class KeywordDocument {
 		keywords.removeIf(k -> k.getKeyword().equals(keyword));
 	}
 
-	public void addChannel(ChannelType channel) {
-		channels.add(channel);
+	public void addChannel(ChannelType channel, String token) {
+
+		channels.add(Channel.of(channel, token));
 	}
 
 	public void deleteChannel(ChannelType channel) {
-		channels.remove(channel);
+		channels.removeIf(c -> c.getChannel().equals(channel));
 	}
 
 	@Getter
@@ -88,6 +89,25 @@ public class KeywordDocument {
 
 		public void deleteExcludeKeyword(String excludeKeyword) {
 			this.excludeKeywords.removeIf(ek -> ek.equals(excludeKeyword));
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Channel{
+		@Enumerated(EnumType.STRING)
+		@Field(type = FieldType.Keyword)
+		private ChannelType channel;
+		@Field(type = FieldType.Keyword)
+		private String token;
+
+		private Channel(ChannelType channel, String token) {
+			this.channel = channel;
+			this.token = token;
+		}
+
+		public static Channel of (ChannelType channel, String token) {
+			return new Channel(channel, token);
 		}
 	}
 }

--- a/src/main/java/com/example/junggoheaven/domain/keyword/repository/KeywordBulkRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/repository/KeywordBulkRepository.java
@@ -1,0 +1,87 @@
+package com.example.junggoheaven.domain.keyword.repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.junggoheaven.domain.keyword.entity.KeywordDocument;
+import com.example.junggoheaven.domain.keyword.entity.UserKeyword;
+import com.example.junggoheaven.domain.user.entity.User;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.MgetResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.get.GetResult;
+import co.elastic.clients.elasticsearch.core.mget.MultiGetOperation;
+import co.elastic.clients.elasticsearch.core.mget.MultiGetResponseItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class KeywordBulkRepository {
+	private final ElasticsearchClient esClient;
+	private BulkRequest.Builder br;
+
+	public List<KeywordDocument> findKeywordDocumentsByIdBetween(List<MultiGetOperation> keywordDocuments) {
+		try {
+			MgetResponse<KeywordDocument> response = esClient.mget(mg -> mg.index("keyword")
+					.docs(keywordDocuments),
+				KeywordDocument.class);
+
+			return response.docs().stream()
+				.filter(item -> item.result().found())
+				.map(item -> item.result().source())
+				.collect(Collectors.toList());
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public void bulkInsertUsers(List<User> users) {
+		List<KeywordDocument> keywordDocuments = users.stream().map(KeywordDocument::of).toList();
+
+		bulk(keywordDocuments);
+	}
+
+	public void bulkInsert(List<KeywordDocument> keywordDocuments) {
+		bulk(keywordDocuments);
+	}
+
+	private void bulk(List<KeywordDocument> keywordDocuments) {
+		br = new BulkRequest.Builder();
+
+		for (KeywordDocument keyword : keywordDocuments) {
+			br.operations(op -> op
+				.index(idx -> idx
+					.index("keyword")
+					.id(keyword.getId())
+					.document(keyword)
+				)
+			);
+		}
+
+		try {
+			BulkResponse result = esClient.bulk(br.build());
+
+			if (result.errors()) {
+				log.error("Bulk had errors");
+				for (BulkResponseItem item: result.items()) {
+					if (item.error() != null) {
+						log.error(item.error().reason());
+					}
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/example/junggoheaven/domain/keyword/repository/KeywordDocumentRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/keyword/repository/KeywordDocumentRepository.java
@@ -1,5 +1,7 @@
 package com.example.junggoheaven.domain.keyword.repository;
 
+import java.util.List;
+
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 import com.example.junggoheaven.domain.keyword.entity.KeywordDocument;

--- a/src/main/java/com/example/junggoheaven/domain/payments/service/payment/TossVirtualAccountService.java
+++ b/src/main/java/com/example/junggoheaven/domain/payments/service/payment/TossVirtualAccountService.java
@@ -73,8 +73,7 @@ public class TossVirtualAccountService implements VirtualAccountService {
 		order.updateStatus(OrderStatus.VIRTUAL_ACCOUNT_ISSUED);
 
 		eventPublisher.publishEventAfterTransaction(
-			new OrderStatusChangeEvent(this,
-				order.getBuyer().getId(),
+			new OrderStatusChangeEvent(this, order.getBuyer().getId(),
 				order.getId()
 					+ " 에 대한 가상계좌가 발급되었습니다.\n"
 					+ order.getDetails()));
@@ -103,7 +102,12 @@ public class TossVirtualAccountService implements VirtualAccountService {
 			case "EXPIRED" -> order.updateStatus(OrderStatus.EXPIRED);                // 결제 유효 시간 30분이 지나 거래가 취소된 상태
 		}
 
-		eventPublisher.publishEventAfterTransaction(new OrderStatusChangeEvent(this, order.getSeller().getId(), tossStatus));
+		eventPublisher.publishEventAfterTransaction(
+			new OrderStatusChangeEvent(this, order.getSeller().getId(),
+			order.getId()
+			+ "에 대한 상태가 변경되었습니다.\n"
+			+ "Status: " + tossStatus));
+
 		return "update status: " + order.getStatus().name();
 	}
 

--- a/src/main/java/com/example/junggoheaven/domain/payments/service/payment/TossVirtualAccountService.java
+++ b/src/main/java/com/example/junggoheaven/domain/payments/service/payment/TossVirtualAccountService.java
@@ -23,6 +23,8 @@ import com.example.junggoheaven.domain.payments.enums.OrderStatus;
 import com.example.junggoheaven.domain.payments.exception.OrderAmountException;
 import com.example.junggoheaven.domain.payments.service.order.OrderFinder;
 import com.example.junggoheaven.global.aop.Payment;
+import com.example.junggoheaven.global.message.event.finder.OrderStatusChangeEvent;
+import com.example.junggoheaven.global.message.publisher.EventPublisher;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class TossVirtualAccountService implements VirtualAccountService {
 	private final RestTemplate restTemplate;
 	private final OrderFinder orderFinder;
 	private final VirtualAccountWriter virtualAccountWriter;
+	private final EventPublisher eventPublisher;
 
 	@Value("${toss.payments.secret-key}")
 	private String SECRET_KEY;
@@ -69,6 +72,13 @@ public class TossVirtualAccountService implements VirtualAccountService {
 		virtualAccountWriter.save(account);
 		order.updateStatus(OrderStatus.VIRTUAL_ACCOUNT_ISSUED);
 
+		eventPublisher.publishEventAfterTransaction(
+			new OrderStatusChangeEvent(this,
+				order.getBuyer().getId(),
+				order.getId()
+					+ " 에 대한 가상계좌가 발급되었습니다.\n"
+					+ order.getDetails()));
+
 		return responseEntity.getBody();
 	}
 
@@ -93,6 +103,7 @@ public class TossVirtualAccountService implements VirtualAccountService {
 			case "EXPIRED" -> order.updateStatus(OrderStatus.EXPIRED);                // 결제 유효 시간 30분이 지나 거래가 취소된 상태
 		}
 
+		eventPublisher.publishEventAfterTransaction(new OrderStatusChangeEvent(this, order.getSeller().getId(), tossStatus));
 		return "update status: " + order.getStatus().name();
 	}
 

--- a/src/main/java/com/example/junggoheaven/domain/user/repository/UserKeywordCustomRepository.java
+++ b/src/main/java/com/example/junggoheaven/domain/user/repository/UserKeywordCustomRepository.java
@@ -6,4 +6,5 @@ import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 
 public interface UserKeywordCustomRepository {
 	List<MatchedUserDto> findAllUserIdByProductName(String productName);
+	MatchedUserDto findMatchedUserDtoById(Long userId);
 }

--- a/src/main/java/com/example/junggoheaven/domain/user/repository/UserKeywordRepositoryImpl.java
+++ b/src/main/java/com/example/junggoheaven/domain/user/repository/UserKeywordRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import com.example.junggoheaven.domain.user.enums.UserStatus;
 import com.example.junggoheaven.global.message.dto.MatchedUserDto;
+import com.example.junggoheaven.global.message.dto.NotificationChannelDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -46,13 +47,45 @@ public class UserKeywordRepositoryImpl implements UserKeywordCustomRepository{
 					Projections.fields(
 						MatchedUserDto.class,
 						user.id.as("userId"),
-						user.name,
-						set(
-							notificationChannel.channelType
-						).as("channelTypes")
+						user.email,
+						list(
+							Projections.fields(
+								NotificationChannelDto.class,
+								notificationChannel.channelType,
+								notificationChannel.token
+							)
+						).as("channels")
 					)
 				)
 			);
+	}
+
+	@Override
+	public MatchedUserDto findMatchedUserDtoById(Long userId) {
+		return jpaQueryFactory
+			.from(user)
+			.leftJoin(notificationChannel)
+			.on(user.id.eq(notificationChannel.user.id))
+			.where(
+				user.id.eq(userId)
+			)
+			.transform(
+				groupBy(user.id).as(
+					Projections.fields(
+						MatchedUserDto.class,
+						user.id.as("userId"),
+						user.email,
+						list(
+							Projections.fields(
+								NotificationChannelDto.class,
+								notificationChannel.channelType,
+								notificationChannel.token
+							)
+						).as("channels")
+					)
+				)
+			)
+			.get(userId);
 	}
 
 	private BooleanExpression notEqualStatus(String status) {

--- a/src/main/java/com/example/junggoheaven/global/config/EmailConfig.java
+++ b/src/main/java/com/example/junggoheaven/global/config/EmailConfig.java
@@ -1,0 +1,58 @@
+package com.example.junggoheaven.global.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import jakarta.mail.Authenticator;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Session;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class EmailConfig {
+	@Value("${spring.mail.host}")
+	private String host;
+	@Value("${spring.mail.port}")
+	private String port;
+	@Value("${spring.mail.username}")
+	private String userName;
+	@Value("${spring.mail.password}")
+	private String password;
+
+
+
+	@Bean
+	JavaMailSender javaMailSender() {
+		JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+		Properties props = new Properties();
+		props.put("mail.smtp.auth", "true"); // 인증 필요
+		props.put("mail.smtp.starttls.enable", "true"); // TLS 시작 명령 필요
+		props.put("mail.smtp.starttls.required", "true"); // "TLS 안되면 아예 실패" 설정
+		props.put("mail.smtp.host", host); // Gmail SMTP 서버
+		props.put("mail.smtp.port", port); // TLS 기본 포트
+
+		Session session = Session.getInstance(props, new Authenticator() {
+			@Override
+			protected PasswordAuthentication getPasswordAuthentication() {
+				return new PasswordAuthentication(userName, password);
+			}
+		});
+		javaMailSender.setSession(session);
+		return javaMailSender;
+	}
+
+	@Bean
+	SimpleMailMessage templateMessage() {
+		SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+		simpleMailMessage.setFrom("JungGo_Heaven@gmail.com");
+		return simpleMailMessage;
+	}
+}

--- a/src/main/java/com/example/junggoheaven/global/message/controller/NotificationChannelController.java
+++ b/src/main/java/com/example/junggoheaven/global/message/controller/NotificationChannelController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.junggoheaven.global.auth.dto.user.AuthUser;
 import com.example.junggoheaven.global.message.dto.CreateNotificationRequestDto;
 import com.example.junggoheaven.global.message.dto.DeleteNotificationRequestDto;
-import com.example.junggoheaven.global.message.service.NotificationChannelService;
+import com.example.junggoheaven.global.message.service.notificationChannel.NotificationChannelService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +23,7 @@ public class NotificationChannelController {
 
 	@PostMapping("/v1/notifications")
 	public ResponseEntity<?> createNotificationChannel(@AuthenticationPrincipal AuthUser authUser, @RequestBody CreateNotificationRequestDto dto) {
-		notificationChannelService.addNotificationChannel(authUser.getId(), dto.getChannelType());
+		notificationChannelService.addNotificationChannel(authUser.getId(), dto.getChannelType(), dto.getToken());
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/example/junggoheaven/global/message/controller/TestController.java
+++ b/src/main/java/com/example/junggoheaven/global/message/controller/TestController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.junggoheaven.domain.keyword.service.MysqlKeywordService;
-import com.example.junggoheaven.global.message.event.TestEventPublisher;
+import com.example.junggoheaven.global.message.publisher.TestEventPublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +27,12 @@ public class TestController {
 	@GetMapping("/v1/publish/{name}")
 	public ResponseEntity<?> testPublishV1(@PathVariable String name) {
 		testEventPublisher.publishProductRegisteredEvent("v1", name);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/v1/publish/OrderStatus/{userId}")
+	public ResponseEntity<?> testPublishOrderStatus(@PathVariable Long userId) {
+		testEventPublisher.publishOrderStatusChangedEvent(userId);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/example/junggoheaven/global/message/dto/CreateNotificationRequestDto.java
+++ b/src/main/java/com/example/junggoheaven/global/message/dto/CreateNotificationRequestDto.java
@@ -13,4 +13,6 @@ public class CreateNotificationRequestDto {
 	@NotBlank(message = "등록하려는 채널을 입력하세요.")
 	@ValidEnum(enumClass = ChannelType.class, message = "알림 채널이 존재하지 않습니다.")
 	private final String channelType;
+
+	private final String token;
 }

--- a/src/main/java/com/example/junggoheaven/global/message/dto/MatchedUserDto.java
+++ b/src/main/java/com/example/junggoheaven/global/message/dto/MatchedUserDto.java
@@ -1,8 +1,8 @@
 package com.example.junggoheaven.global.message.dto;
 
-import java.util.Set;
+import java.util.List;
 
-import com.example.junggoheaven.global.message.enums.ChannelType;
+import com.example.junggoheaven.domain.keyword.entity.KeywordDocument;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,6 +13,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MatchedUserDto {
 	private Long userId;
-	private String name;
-	private Set<ChannelType> channelTypes;
+	private String email;
+	private List<NotificationChannelDto> channels;
+
+	public static MatchedUserDto of(KeywordDocument keywordDocument) {
+		return new MatchedUserDto(
+			Long.parseLong(keywordDocument.getId()),
+			keywordDocument.getEmail(),
+			NotificationChannelDto.ofList(keywordDocument.getChannels()));
+	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/dto/NotificationChannelDto.java
+++ b/src/main/java/com/example/junggoheaven/global/message/dto/NotificationChannelDto.java
@@ -1,0 +1,27 @@
+package com.example.junggoheaven.global.message.dto;
+
+import java.util.List;
+
+import com.example.junggoheaven.domain.keyword.entity.KeywordDocument;
+import com.example.junggoheaven.global.message.enums.ChannelType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationChannelDto {
+	private ChannelType channelType;
+	private String token;
+
+	private NotificationChannelDto(KeywordDocument.Channel channel) {
+		this.channelType = channel.getChannel();
+		this.token = channel.getToken();
+	}
+
+	public static List<NotificationChannelDto> ofList(List<KeywordDocument.Channel> channels) {
+		return channels.stream().map(NotificationChannelDto::new).toList();
+	}
+}

--- a/src/main/java/com/example/junggoheaven/global/message/entity/NotificationChannel.java
+++ b/src/main/java/com/example/junggoheaven/global/message/entity/NotificationChannel.java
@@ -28,16 +28,20 @@ public class NotificationChannel {
 	@Column(nullable = false)
 	private ChannelType channelType;
 
+	@Column(nullable = false)
+	private String token;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	private NotificationChannel (ChannelType channelType, User user) {
+	private NotificationChannel (ChannelType channelType, String token, User user) {
 		this.channelType = channelType;
+		this.token = token;
 		this.user = user;
 	}
 
-	public static NotificationChannel of(ChannelType channelType, User user) {
-		return new NotificationChannel(channelType, user);
+	public static NotificationChannel of(ChannelType channelType, String token, User user) {
+		return new NotificationChannel(channelType, token, user);
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/enums/NotificationType.java
+++ b/src/main/java/com/example/junggoheaven/global/message/enums/NotificationType.java
@@ -1,5 +1,5 @@
 package com.example.junggoheaven.global.message.enums;
 
 public enum NotificationType {
-	PRODUCT_REGISTRATION, INQUIRY_REGISTRATION, INQUIRY_RESPONSE
+	PRODUCT_REGISTRATION, INQUIRY_REGISTRATION, INQUIRY_RESPONSE, ORDER_CHANGE
 }

--- a/src/main/java/com/example/junggoheaven/global/message/event/NotificationEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/NotificationEvent.java
@@ -1,7 +1,11 @@
 package com.example.junggoheaven.global.message.event;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.context.ApplicationEvent;
 
+import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 import com.example.junggoheaven.global.message.entity.NotificationEventLog;
 import com.example.junggoheaven.global.message.enums.NotificationType;
 
@@ -13,6 +17,7 @@ public class NotificationEvent extends ApplicationEvent {
 	private final Long userId;
 	private final NotificationType notificationType;
 	private final String notificationMessage;
+	private final List<MatchedUserDto> userList;
 	@Setter
 	private NotificationEventLog notificationEventLog;
 
@@ -21,5 +26,6 @@ public class NotificationEvent extends ApplicationEvent {
 		this.userId = userId;
 		this.notificationType = notificationType;
 		this.notificationMessage = notificationMessage;
+		this.userList = new ArrayList<>();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/event/finder/OrderStatusChangeEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/finder/OrderStatusChangeEvent.java
@@ -1,0 +1,10 @@
+package com.example.junggoheaven.global.message.event.finder;
+
+import com.example.junggoheaven.global.message.enums.NotificationType;
+import com.example.junggoheaven.global.message.event.NotificationEvent;
+
+public class OrderStatusChangeEvent extends NotificationEvent {
+	public OrderStatusChangeEvent(Object source, Long userId, String notificationMessage) {
+		super(source, userId, NotificationType.ORDER_CHANGE, notificationMessage);
+	}
+}

--- a/src/main/java/com/example/junggoheaven/global/message/event/mapper/ChannelMappingEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/mapper/ChannelMappingEvent.java
@@ -10,11 +10,10 @@ import lombok.Getter;
 
 @Getter
 public class ChannelMappingEvent extends NotificationEvent {
-	private final List<MatchedUserDto> userList;
 
 	public ChannelMappingEvent(Object source, Long userId,
 		NotificationType notificationType, String notificationMessage, List<MatchedUserDto> userList) {
 		super(source, userId, notificationType, notificationMessage);
-		this.userList = userList;
+		this.getUserList().addAll(userList);
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByEmailEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByEmailEvent.java
@@ -11,10 +11,8 @@ import lombok.Getter;
 
 @Getter
 public final class PushByEmailEvent extends NotificationEvent {
-	private final List<MatchedUserDto> userList;
 
 	public PushByEmailEvent(Object source, Long userId, NotificationType notificationType, String notificationMessage) {
 		super(source, userId, notificationType, notificationMessage);
-		this.userList = new ArrayList<>();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByFCMEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByFCMEvent.java
@@ -11,11 +11,9 @@ import lombok.Getter;
 
 @Getter
 public class PushByFCMEvent extends NotificationEvent {
-	private final List<MatchedUserDto> userList;
 
 	public PushByFCMEvent(Object source, Long userId,
 		NotificationType notificationType, String notificationMessage) {
 		super(source, userId, notificationType, notificationMessage);
-		this.userList = new ArrayList<>();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByKakaoEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByKakaoEvent.java
@@ -11,10 +11,9 @@ import lombok.Getter;
 
 @Getter
 public class PushByKakaoEvent extends NotificationEvent {
-	private final List<MatchedUserDto> userList;
+
 	public PushByKakaoEvent(Object source, Long userId,
 		NotificationType notificationType, String notificationMessage) {
 		super(source, userId, notificationType, notificationMessage);
-		this.userList = new ArrayList<>();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByWebPushEvent.java
+++ b/src/main/java/com/example/junggoheaven/global/message/event/pusher/PushByWebPushEvent.java
@@ -11,11 +11,9 @@ import lombok.Getter;
 
 @Getter
 public class PushByWebPushEvent extends NotificationEvent {
-	private final List<MatchedUserDto> userList;
 
 	public PushByWebPushEvent(Object source, Long userId,
 		NotificationType notificationType, String notificationMessage) {
 		super(source, userId, notificationType, notificationMessage);
-		this.userList = new ArrayList<>();
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/finder/ESKeywordMatchedUserFinder.java
+++ b/src/main/java/com/example/junggoheaven/global/message/finder/ESKeywordMatchedUserFinder.java
@@ -1,0 +1,135 @@
+package com.example.junggoheaven.global.message.finder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.example.junggoheaven.domain.keyword.entity.KeywordDocument;
+import com.example.junggoheaven.global.message.dto.MatchedUserDto;
+import com.example.junggoheaven.global.message.event.finder.ProductRegisteredEvent;
+import com.example.junggoheaven.global.message.event.mapper.ChannelMappingEvent;
+import com.example.junggoheaven.global.message.publisher.EventPublisher;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.indices.AnalyzeResponse;
+import co.elastic.clients.elasticsearch.indices.analyze.AnalyzeToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ESKeywordMatchedUserFinder {
+	private final ElasticsearchClient esClient;
+	private final EventPublisher eventPublisher;
+
+	/*
+	 * 상품 게시글 등록시 해당 게시글 이름에 포함된 Keyword 를 등록한 User 를 선별하는 Component
+	 * 선별 후 채널을 분류하는 ChannelMapper 를 호출한다.
+	 * ElasticSearch 에 Term Query 를 통해서 선별한다.
+	 * */
+
+	@Async
+	@EventListener
+	public void findKeywordMatchedUser(ProductRegisteredEvent event) {
+		long startedAt = System.currentTimeMillis();
+		String name = event.getNotificationMessage();
+
+		/*
+		* Bool Query 에서 Must 부분을 담당한다.
+		* 사용자가 등록한 키워드와 일치 할 경우 선별한다.
+		* */
+
+		Query must = MatchQuery.of(m -> m
+			.field("keywords.keyword")
+			.query(name))
+			._toQuery();
+
+		/*
+		* Bool Query 에서 Must_Not 을 담당한다.
+		* 사용자가 등록한 키워드에서 제외키워드와 일치 할 경우 선별 대상에서 제외한다.
+		* */
+
+		Query mustNot = MatchQuery.of(m -> m
+			.field("keywords.excludeKeywords")
+			.query(name))
+			._toQuery();
+
+		try {
+			SearchResponse<KeywordDocument> response = esClient.search(s -> s
+				.index("keyword")
+					.scroll(t -> t.time("1m"))
+					.size(10000)
+					.query(q -> q
+						.nested(n -> n
+							.path("keywords")
+							.query(nq -> nq
+								.bool(b -> b
+									.must(must)
+									.mustNot(mustNot))
+							)
+						)
+					),
+				KeywordDocument.class
+			);
+
+			/*
+			* ElasticSearch 는 한번에 최대 10000개의 Document 만 Search 가능하다.
+			* 따라서 대상 Document 가 10000개를 초과 할 경우 scrollId 를 기억해서 반복 요청을 보낸다.
+			* */
+
+			String scrollId = response.scrollId();
+
+			List<Hit<KeywordDocument>> hits = response.hits().hits();
+			List<MatchedUserDto> userList = new ArrayList<>(hits.stream()
+				.map(Hit::source)
+				.filter(Objects::nonNull)
+				.map(MatchedUserDto::of)
+				.toList());
+
+			while (true) {
+				String finalScrollId = scrollId;
+				ScrollResponse<KeywordDocument> scrollResponse = esClient.scroll(s -> s
+						.scrollId(finalScrollId)
+						.scroll(t -> t.time("1m")),
+					KeywordDocument.class);
+
+				scrollId = scrollResponse.scrollId();
+
+				userList.addAll(scrollResponse.hits().hits().stream()
+					.map(Hit::source)
+					.filter(Objects::nonNull)
+					.map(MatchedUserDto::of)
+					.toList());
+
+				if (scrollResponse.hits().hits().isEmpty()) break;
+			}
+
+			String finalScrollId1 = scrollId;
+			esClient.clearScroll(c -> c.scrollId(finalScrollId1));
+
+			log.info("ElasticSearch End: {}", System.currentTimeMillis() - startedAt);
+			log.info("Total Users by ES are {}", userList.size());
+			eventPublisher.publishEvent(
+				new ChannelMappingEvent(event.getSource(),
+					event.getUserId(),
+					event.getNotificationType(),
+					event.getNotificationMessage(),
+					userList
+				));
+			log.info("ESKeywordMatchedUserFinder Done");
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/example/junggoheaven/global/message/finder/KeywordMatchedUserFinder.java
+++ b/src/main/java/com/example/junggoheaven/global/message/finder/KeywordMatchedUserFinder.java
@@ -25,16 +25,17 @@ public class KeywordMatchedUserFinder {
 	/*
 	* 상품 게시글 등록시 해당 게시글 이름에 포함된 Keyword 를 등록한 User 를 선별하는 Component
 	* 선별 후 채널을 분류하는 ChannelMapper 를 호출한다.
+	* Mysql DataBase 에서 Like Query 를 통해서 선별한다.
 	* */
 	@Async
-	@EventListener
+	// @EventListener
 	public void findKeywordMatchedUser(ProductRegisteredEvent event) {
 		long startedAt = System.currentTimeMillis();
 		String name = event.getNotificationMessage();
 
 		List<MatchedUserDto> userList = userKeywordRepository.findAllUserIdByProductName(name);
-		log.info("End: {}", System.currentTimeMillis() - startedAt);
-		log.info("Total Users are {}", userList.size());
+		log.info("Mysql End: {}", System.currentTimeMillis() - startedAt);
+		log.info("Total Users by Mysql are {}", userList.size());
 		eventPublisher.publishEvent( new ChannelMappingEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage(), userList));
 		log.info("KeywordMatchedUserFinder Done");
 	}

--- a/src/main/java/com/example/junggoheaven/global/message/finder/OrderSellerFinder.java
+++ b/src/main/java/com/example/junggoheaven/global/message/finder/OrderSellerFinder.java
@@ -1,0 +1,32 @@
+package com.example.junggoheaven.global.message.finder;
+
+import java.util.List;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.example.junggoheaven.domain.user.repository.UserKeywordRepository;
+import com.example.junggoheaven.global.message.dto.MatchedUserDto;
+import com.example.junggoheaven.global.message.event.finder.OrderStatusChangeEvent;
+import com.example.junggoheaven.global.message.event.mapper.ChannelMappingEvent;
+import com.example.junggoheaven.global.message.publisher.EventPublisher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderSellerFinder {
+	private final EventPublisher eventPublisher;
+	private final UserKeywordRepository keywordRepository;
+
+	@Async
+	@EventListener
+	public void findOrderSeller(OrderStatusChangeEvent event) {
+		List<MatchedUserDto> userList = List.of(keywordRepository.findMatchedUserDtoById(event.getUserId()));
+
+		eventPublisher.publishEvent( new ChannelMappingEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage(), userList));
+	}
+}

--- a/src/main/java/com/example/junggoheaven/global/message/mapper/UserChannelMapper.java
+++ b/src/main/java/com/example/junggoheaven/global/message/mapper/UserChannelMapper.java
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import com.example.junggoheaven.global.message.dto.MatchedUserDto;
+import com.example.junggoheaven.global.message.dto.NotificationChannelDto;
 import com.example.junggoheaven.global.message.enums.ChannelType;
 import com.example.junggoheaven.global.message.event.mapper.ChannelMappingEvent;
 import com.example.junggoheaven.global.message.event.pusher.PushByEmailEvent;
@@ -40,7 +41,7 @@ public class UserChannelMapper {
 		PushByWebPushEvent web = new PushByWebPushEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage());
 
 		userList.forEach(user -> {
-			Set<ChannelType> channelTypes = user.getChannelTypes();
+			List<ChannelType> channelTypes = user.getChannels().stream().map(NotificationChannelDto::getChannelType).toList();
 			for (ChannelType channelType : channelTypes) {
 				switch (channelType) {
 					case KAKAO_TALK:

--- a/src/main/java/com/example/junggoheaven/global/message/mapper/UserChannelMapper.java
+++ b/src/main/java/com/example/junggoheaven/global/message/mapper/UserChannelMapper.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 import com.example.junggoheaven.global.message.dto.NotificationChannelDto;
 import com.example.junggoheaven.global.message.enums.ChannelType;
+import com.example.junggoheaven.global.message.event.NotificationEvent;
 import com.example.junggoheaven.global.message.event.mapper.ChannelMappingEvent;
 import com.example.junggoheaven.global.message.event.pusher.PushByEmailEvent;
 import com.example.junggoheaven.global.message.event.pusher.PushByFCMEvent;
@@ -36,17 +37,15 @@ public class UserChannelMapper {
 	public void channelMapper(ChannelMappingEvent event) {
 		List<MatchedUserDto> userList = event.getUserList();
 		PushByEmailEvent email = new PushByEmailEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage());
-		PushByKakaoEvent kakao = new PushByKakaoEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage());
 		PushByFCMEvent fcm = new PushByFCMEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage());
 		PushByWebPushEvent web = new PushByWebPushEvent(event.getSource(), event.getUserId(), event.getNotificationType(), event.getNotificationMessage());
+
+		List<NotificationEvent> events = List.of(email, fcm, web);
 
 		userList.forEach(user -> {
 			List<ChannelType> channelTypes = user.getChannels().stream().map(NotificationChannelDto::getChannelType).toList();
 			for (ChannelType channelType : channelTypes) {
 				switch (channelType) {
-					case KAKAO_TALK:
-						kakao.getUserList().add(user);
-						break;
 					case EMAIL:
 						email.getUserList().add(user);
 						break;
@@ -60,17 +59,13 @@ public class UserChannelMapper {
 			}
 		});
 
-		log.info("총 사용자 수: {}, Email 사용자 수: {}, KakaoTalk 사용자 수: {}, FCM 사용자 수: {}, Web Push 사용자 수: {}",
+		log.info("총 사용자 수: {}, Email 사용자 수: {}, FCM 사용자 수: {}, Web Push 사용자 수: {}",
 			userList.size(),
 			email.getUserList().size(),
-			kakao.getUserList().size(),
 			fcm.getUserList().size(),
 			web.getUserList().size()
 		);
 
-		eventPublisher.publishEvent(email);
-		eventPublisher.publishEvent(kakao);
-		eventPublisher.publishEvent(fcm);
-		eventPublisher.publishEvent(web);
+		events.stream().filter(e -> !e.getUserList().isEmpty()).forEach(eventPublisher::publishEvent);
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/publisher/EventPublisher.java
+++ b/src/main/java/com/example/junggoheaven/global/message/publisher/EventPublisher.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import com.example.junggoheaven.global.message.entity.NotificationEventLog;
 import com.example.junggoheaven.global.message.event.NotificationEvent;
-import com.example.junggoheaven.global.message.service.component.writer.NotificationEventLogWriter;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.writer.NotificationEventLogWriter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/junggoheaven/global/message/publisher/TestEventPublisher.java
+++ b/src/main/java/com/example/junggoheaven/global/message/publisher/TestEventPublisher.java
@@ -1,8 +1,8 @@
-package com.example.junggoheaven.global.message.event;
+package com.example.junggoheaven.global.message.publisher;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
+import com.example.junggoheaven.global.message.event.finder.OrderStatusChangeEvent;
 import com.example.junggoheaven.global.message.event.finder.ProductRegisteredEvent;
 
 import lombok.RequiredArgsConstructor;
@@ -10,11 +10,15 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class TestEventPublisher {
-	private final ApplicationEventPublisher eventPublisher;
+	private final EventPublisher eventPublisher;
 
 	public void publishProductRegisteredEvent(String version, String name) {
 		if (version.equals("v1")) {
 			eventPublisher.publishEvent(new ProductRegisteredEvent(this, 2L, name));
 		}
+	}
+
+	public void publishOrderStatusChangedEvent(Long userId) {
+		eventPublisher.publishEvent(new OrderStatusChangeEvent(this, userId, "DONE"));
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/pusher/EmailPusher.java
+++ b/src/main/java/com/example/junggoheaven/global/message/pusher/EmailPusher.java
@@ -10,7 +10,8 @@ import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 import com.example.junggoheaven.global.message.entity.NotificationDeliveryLog;
 import com.example.junggoheaven.global.message.enums.ChannelType;
 import com.example.junggoheaven.global.message.event.pusher.PushByEmailEvent;
-import com.example.junggoheaven.global.message.service.component.writer.NotificationDeliveryEventWriter;
+import com.example.junggoheaven.global.message.service.email.EmailService;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.writer.NotificationDeliveryEventWriter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,19 +21,23 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class EmailPusher {
 	private final NotificationDeliveryEventWriter notificationDeliveryEventWriter;
+	private final EmailService emailService;
 
 	@Async
 	@EventListener
 	public void productRegisteredMessagePusher(PushByEmailEvent event) {
 		List<MatchedUserDto> userList = event.getUserList();
 		int count = 0;
+
 		for (MatchedUserDto user : userList) {
 			// push 알림
+			emailService.sendEmail(user.getEmail(), event.getNotificationType().name(), event.getNotificationMessage());
 			count++;
 		}
 
 		// 알림 방식 로그로 저장
 		log.info("총 {} 명의 사용자 에게 알림 {} 을/를 보냈습니다.", count, ChannelType.EMAIL);
+		// emailService.sendEmail("ahkiler@naver.com", event.getNotificationType().name(), event.getNotificationMessage());
 
 		NotificationDeliveryLog notificationDeliveryLog = NotificationDeliveryLog.builder()
 			.channelType(ChannelType.EMAIL)

--- a/src/main/java/com/example/junggoheaven/global/message/pusher/FCMPusher.java
+++ b/src/main/java/com/example/junggoheaven/global/message/pusher/FCMPusher.java
@@ -10,7 +10,7 @@ import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 import com.example.junggoheaven.global.message.entity.NotificationDeliveryLog;
 import com.example.junggoheaven.global.message.enums.ChannelType;
 import com.example.junggoheaven.global.message.event.pusher.PushByFCMEvent;
-import com.example.junggoheaven.global.message.service.component.writer.NotificationDeliveryEventWriter;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.writer.NotificationDeliveryEventWriter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/junggoheaven/global/message/pusher/KakaoTalkPusher.java
+++ b/src/main/java/com/example/junggoheaven/global/message/pusher/KakaoTalkPusher.java
@@ -10,7 +10,7 @@ import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 import com.example.junggoheaven.global.message.entity.NotificationDeliveryLog;
 import com.example.junggoheaven.global.message.enums.ChannelType;
 import com.example.junggoheaven.global.message.event.pusher.PushByKakaoEvent;
-import com.example.junggoheaven.global.message.service.component.writer.NotificationDeliveryEventWriter;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.writer.NotificationDeliveryEventWriter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/junggoheaven/global/message/pusher/WebPushPusher.java
+++ b/src/main/java/com/example/junggoheaven/global/message/pusher/WebPushPusher.java
@@ -10,7 +10,7 @@ import com.example.junggoheaven.global.message.dto.MatchedUserDto;
 import com.example.junggoheaven.global.message.entity.NotificationDeliveryLog;
 import com.example.junggoheaven.global.message.enums.ChannelType;
 import com.example.junggoheaven.global.message.event.pusher.PushByWebPushEvent;
-import com.example.junggoheaven.global.message.service.component.writer.NotificationDeliveryEventWriter;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.writer.NotificationDeliveryEventWriter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/junggoheaven/global/message/repository/NotificationChannelBulkRepository.java
+++ b/src/main/java/com/example/junggoheaven/global/message/repository/NotificationChannelBulkRepository.java
@@ -16,11 +16,12 @@ public class NotificationChannelBulkRepository {
 
 	private static final int BATCH_SIZE = 1000;
 	public void insert(List<NotificationChannel> notificationChannels) {
-		String sql = "INSERT INTO notification_channel (user_id, channel_type) VALUES (?, ?)";
+		String sql = "INSERT INTO notification_channel (user_id, channel_type, token) VALUES (?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql, notificationChannels, BATCH_SIZE, (ps, notificationChannel) -> {
 			ps.setLong(1, notificationChannel.getUser().getId());
 			ps.setString(2, notificationChannel.getChannelType().name());
+			ps.setString(3, notificationChannel.getToken());
 		});
 	}
 }

--- a/src/main/java/com/example/junggoheaven/global/message/service/email/EmailService.java
+++ b/src/main/java/com/example/junggoheaven/global/message/service/email/EmailService.java
@@ -1,0 +1,33 @@
+package com.example.junggoheaven.global.message.service.email;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+	private final JavaMailSender mailSender;
+	private final SimpleMailMessage templateMessage;
+
+	public void sendEmail(String to, String subject, String text) {
+		// Create a thread-safe "copy" of the template message and customize it
+		SimpleMailMessage msg = new SimpleMailMessage(this.templateMessage);
+
+		msg.setTo(to);
+		msg.setSubject(subject);
+		msg.setText(text);
+
+		try {
+			mailSender.send(msg);
+			log.info("Email sent successfully");
+		} catch (MailException e) {
+			log.error("{} 에게 메일을 보낼 수 없습니다.\nReason: {}", to, e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/NotificationChannelService.java
+++ b/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/NotificationChannelService.java
@@ -1,4 +1,4 @@
-package com.example.junggoheaven.global.message.service;
+package com.example.junggoheaven.global.message.service.notificationChannel;
 
 import java.util.List;
 
@@ -12,8 +12,8 @@ import com.example.junggoheaven.domain.user.entity.User;
 import com.example.junggoheaven.domain.user.service.component.UserFinder;
 import com.example.junggoheaven.global.message.entity.NotificationChannel;
 import com.example.junggoheaven.global.message.enums.ChannelType;
-import com.example.junggoheaven.global.message.service.component.finder.NotificationChannelFinder;
-import com.example.junggoheaven.global.message.service.component.writer.NotificationChannelWriter;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.finder.NotificationChannelFinder;
+import com.example.junggoheaven.global.message.service.notificationChannel.component.writer.NotificationChannelWriter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +27,7 @@ public class NotificationChannelService {
 	private final KeywordWriter keywordWriter;
 	private final UserFinder userFinder;
 
-	public void addNotificationChannel(Long userId, String channelType) {
+	public void addNotificationChannel(Long userId, String channelType, String token) {
 		User user = userFinder.findByUserId(userId);
 		List<NotificationChannel> NotiList = notificationChannelFinder.findByUserId(user.getId());
 
@@ -41,10 +41,10 @@ public class NotificationChannelService {
 			}
 		}
 
-		NotificationChannel notificationChannel = NotificationChannel.of(type, user);
+		NotificationChannel notificationChannel = NotificationChannel.of(type, token, user);
 		notificationChannelWriter.write(notificationChannel);
 
-		savedUser.addChannel(type);
+		savedUser.addChannel(type, token);
 		keywordWriter.write(savedUser);
 	}
 

--- a/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/finder/NotificationChannelFinder.java
+++ b/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/finder/NotificationChannelFinder.java
@@ -1,4 +1,4 @@
-package com.example.junggoheaven.global.message.service.component.finder;
+package com.example.junggoheaven.global.message.service.notificationChannel.component.finder;
 
 import java.util.List;
 

--- a/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/writer/NotificationChannelWriter.java
+++ b/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/writer/NotificationChannelWriter.java
@@ -1,4 +1,4 @@
-package com.example.junggoheaven.global.message.service.component.writer;
+package com.example.junggoheaven.global.message.service.notificationChannel.component.writer;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/writer/NotificationDeliveryEventWriter.java
+++ b/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/writer/NotificationDeliveryEventWriter.java
@@ -1,4 +1,4 @@
-package com.example.junggoheaven.global.message.service.component.writer;
+package com.example.junggoheaven.global.message.service.notificationChannel.component.writer;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/writer/NotificationEventLogWriter.java
+++ b/src/main/java/com/example/junggoheaven/global/message/service/notificationChannel/component/writer/NotificationEventLogWriter.java
@@ -1,4 +1,4 @@
-package com.example.junggoheaven.global.message.service.component.writer;
+package com.example.junggoheaven.global.message.service.notificationChannel.component.writer;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/resources/elastic/keyword-mapping.json
+++ b/src/main/resources/elastic/keyword-mapping.json
@@ -1,36 +1,29 @@
 {
   "properties": {
     "id": {
-      "type": "text"
+      "type": "keyword"
     },
     "email": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 100
-        }
-      }
+      "type": "keyword"
     },
     "keywords": {
       "type": "nested",
       "properties": {
         "keyword": {
-          "type": "keyword",
-          "ignore_above": 20
+          "type": "text"
         },
-        "excludeKeywords": {
-          "type": "keyword",
-          "ignore_above": 20
+        "exclude_keywords": {
+          "type": "text"
         }
       }
     },
     "channels": {
-      "type": "keyword",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 20
+      "properties": {
+        "channel": {
+          "type": "keyword"
+        },
+        "token": {
+          "type": "keyword"
         }
       }
     }

--- a/src/test/java/com/example/junggoheaven/domain/keyword/bulk/KeywordBulkInsertTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/keyword/bulk/KeywordBulkInsertTest.java
@@ -1,30 +1,40 @@
-// package com.example.junggoheaven.domain.user.service;
+// package com.example.junggoheaven.domain.keyword.bulk;
 //
 //
 // import java.util.ArrayList;
 // import java.util.List;
 // import java.util.Random;
 // import java.util.UUID;
+// import java.util.stream.LongStream;
 //
+// import org.junit.jupiter.api.MethodOrderer;
+// import org.junit.jupiter.api.Order;
 // import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.TestMethodOrder;
 // import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 // import org.springframework.boot.test.context.SpringBootTest;
 // import org.springframework.test.context.ActiveProfiles;
-// import org.springframework.test.context.TestPropertySource;
+// import org.springframework.test.util.ReflectionTestUtils;
 //
+// import com.example.junggoheaven.domain.keyword.entity.KeywordDocument;
+// import com.example.junggoheaven.domain.keyword.repository.KeywordBulkRepository;
+// import com.example.junggoheaven.domain.keyword.repository.KeywordDocumentRepository;
 // import com.example.junggoheaven.domain.user.entity.User;
 // import com.example.junggoheaven.domain.keyword.entity.UserKeyword;
 // import com.example.junggoheaven.domain.user.repository.UserBulkRepository;
 // import com.example.junggoheaven.domain.user.repository.UserKeywordBulkRepository;
+// import com.example.junggoheaven.domain.user.repository.UserKeywordRepository;
 // import com.example.junggoheaven.domain.user.repository.UserRepository;
 // import com.example.junggoheaven.global.message.entity.NotificationChannel;
 // import com.example.junggoheaven.global.message.enums.ChannelType;
 // import com.example.junggoheaven.global.message.repository.NotificationChannelBulkRepository;
 //
+// import co.elastic.clients.elasticsearch.core.mget.MultiGetOperation;
+//
 // @SpringBootTest
 // @ActiveProfiles("test")
-// class UserKeywordServiceTest {
+// @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+// class KeywordBulkInsertTest {
 //
 // 	@Autowired
 // 	private UserBulkRepository userBulkRepository;
@@ -34,45 +44,59 @@
 // 	private NotificationChannelBulkRepository notificationChannelBulkRepository;
 // 	@Autowired
 // 	private UserRepository userRepository;
+// 	@Autowired
+// 	private KeywordBulkRepository keywordBulkRepository;
 //
-// 	private static final int TOTAL_USERS = 1_000_000;
+// 	private static final int TOTAL_USERS = 10_000;
 // 	private static final int BATCH_SIZE = 1000;
 // 	private static final String[] KEYWORDS = {
 // 		"강아지", "고양이", "아이폰 3", "아이폰11", "책상", "의자", "냉장고", "나이키 신발", "아디다스 가방", "크록스"
 // 	};
 // 	private static final String[] CHANNELS = {
-// 		"카카오톡", "Wep Push", "FCM", "EMAIL"
+// 		ChannelType.KAKAO_TALK.name(), ChannelType.EMAIL.name(), ChannelType.WEB_PUSH.name(), ChannelType.FCM.name()
 // 	};
 //
+//
+// 	@Order(0)
 // 	@Test
 // 	public void bulkInsertUserTest() {
 // 		Random random = new Random();
 //
 // 		for (int i = 0; i < TOTAL_USERS; i += BATCH_SIZE) {
 // 			List<User> users = new ArrayList<>();
+// 			Long startId = (long)i + 1;
+// 			Long endId = (long)i + BATCH_SIZE;
+//
 //
 // 			for (int j = 0; j < BATCH_SIZE; j++) {
-// 				String email = "user" + UUID.randomUUID() + "@example.com";
-// 				String name = "name" + random.nextInt(1000000);
-// 				String phoneNumber = "" + random.nextInt(1000000);
+// 				String email = "testUser" + (i + j) + "@example.com";
+// 				String name = "name" + random.nextInt(TOTAL_USERS);
+// 				String phoneNumber = "" + random.nextInt(TOTAL_USERS);
 //
-// 				User user = new User(email, name, phoneNumber);
+// 				User user = User.builder().email(email).name(name).phoneNumber(phoneNumber).build();
 // 				users.add(user);
 // 			}
 //
 // 			userBulkRepository.bulkInsert(users);
+// 			List<User> savedUsers = userRepository.findUsersByIdBetween(startId, endId);
+// 			keywordBulkRepository.bulkInsertUsers(savedUsers);
 // 		}
 // 	}
 //
+// 	@Order(1)
 // 	@Test
 // 	void bulkInsertUserKeywordsTest() {
 // 		Random random = new Random();
 //
 // 		for (int i = 0; i < TOTAL_USERS; i += BATCH_SIZE / 10) {
 // 			int userIndex = i - 1;
+// 			Long startId = (long)i + 1;
+// 			Long endId = (long)i + (BATCH_SIZE / 10);
 //
 // 			List<UserKeyword> userKeywords = new ArrayList<>();
-// 			List<User> users = userRepository.findUsersByIdBetween((long)i + 1, (long)i + 100L);
+// 			List<User> users = userRepository.findUsersByIdBetween(startId, endId);
+// 			List<MultiGetOperation> kds = makeKeywordDocumentsByIdBetween(startId, endId);
+// 			List<KeywordDocument> keywordDocuments = keywordBulkRepository.findKeywordDocumentsByIdBetween(kds);
 // 			for (int j = 0; j < BATCH_SIZE; j++) {
 // 				if (j % KEYWORDS.length == 0) {
 // 					userIndex++;
@@ -80,30 +104,47 @@
 //
 // 				String keyword = KEYWORDS[random.nextInt(KEYWORDS.length)];
 //
-// 				UserKeyword userKeyword = UserKeyword.of(keyword, users.get(userIndex % 100));
+// 				UserKeyword userKeyword = UserKeyword.of(keyword, users.get(userIndex % (BATCH_SIZE / 10)));
 // 				userKeywords.add(userKeyword);
-// 			}
 //
+// 				keywordDocuments.get(userIndex % (BATCH_SIZE / 10)).addKeyword(KeywordDocument.Keyword.of(keyword));
+// 			}
+// 			keywordBulkRepository.bulkInsert(keywordDocuments);
 // 			userKeywordBulkRepository.bulkInsert(userKeywords);
 // 		}
 // 	}
 //
+// 	List<MultiGetOperation> makeKeywordDocumentsByIdBetween(long startId, long endId) {
+// 		return LongStream.rangeClosed(startId, endId)
+// 			.mapToObj(i -> new MultiGetOperation.Builder()
+// 				.id(String.valueOf(i))
+// 				.build()).toList();
+// 	}
+//
+// 	@Order(2)
 // 	@Test
 // 	void bulkInsertUserChannelsTest() {
-// 		for (int i = 0; i < TOTAL_USERS / 10; i += BATCH_SIZE) {
+// 		for (int i = 0; i < TOTAL_USERS; i += (BATCH_SIZE / 25) * 10) {
 // 			int userIndex = i - 1;
+// 			Long startId = (long)i + 1;
+// 			Long endId = (long)i + (BATCH_SIZE / 25) * 10;
 //
 // 			List<NotificationChannel> channels = new ArrayList<>();
-// 			List<User> users = userRepository.findUsersByIdBetween((long)i + 1, (long)i + 1000L);
-// 			for (int j = 0; j < BATCH_SIZE; j++) {
+// 			List<User> users = userRepository.findUsersByIdBetween(startId, endId);
+// 			List<MultiGetOperation> kds = makeKeywordDocumentsByIdBetween(startId, endId);
+// 			List<KeywordDocument> keywordDocuments = keywordBulkRepository.findKeywordDocumentsByIdBetween(kds);
+// 			for (int j = 0; j < (BATCH_SIZE / 25) * 10; j++) {
 // 				userIndex++;
 //
 // 				for (int l = 0; l <= j % CHANNELS.length; l++) {
-// 					NotificationChannel nc = NotificationChannel
-// 						.of(ChannelType.values()[l], users.get(userIndex % 1000));
+// 					NotificationChannel nc = NotificationChannel.of
+// 						(ChannelType.values()[l], "token", users.get(userIndex % ((BATCH_SIZE / 25) * 10)));
 // 					channels.add(nc);
+//
+// 					keywordDocuments.get(userIndex % ((BATCH_SIZE / 25) * 10)).addChannel(ChannelType.values()[l], "token");
 // 				}
 // 			}
+// 			keywordBulkRepository.bulkInsert(keywordDocuments);
 // 			notificationChannelBulkRepository.insert(channels);
 // 		}
 // 	}

--- a/src/test/java/com/example/junggoheaven/domain/payments/service/payment/TossVirtualAccountServiceTest.java
+++ b/src/test/java/com/example/junggoheaven/domain/payments/service/payment/TossVirtualAccountServiceTest.java
@@ -29,6 +29,7 @@ import com.example.junggoheaven.domain.payments.exception.OrderAmountException;
 import com.example.junggoheaven.domain.payments.service.order.OrderFinder;
 import com.example.junggoheaven.domain.product.entity.Product;
 import com.example.junggoheaven.domain.user.entity.User;
+import com.example.junggoheaven.global.message.publisher.EventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class TossVirtualAccountServiceTest {
@@ -41,6 +42,8 @@ class TossVirtualAccountServiceTest {
 	private OrderFinder orderFinder;
 	@Mock
 	private VirtualAccountWriter virtualAccountWriter;
+	@Mock
+	private EventPublisher eventPublisher;
 
 	VirtualAccount virtualAccount;
 	VirtualAccountInfo accountInfo;


### PR DESCRIPTION
```
FEAT

OrderStatus 변경시 판매자가 EMAIL 을 NotificationChannel 로 등록을 했다면
해당 판매자에게 EMAIL 알림을 보내는 기능을 추가했습니다.

NotificationChannel 은 로그인 후 http://localhost:8080/api/v1/notifications 로 POST 요청 하시면 등록됩니다.
{
    "channelType": "EMAIL",
    "token": "ahkiler@naver.com"
}

----------------------------------------------------------------------------------------
FEAT

기존 ElasticSearch 를 통한 Keyword 등록 사용자 선별 기능이 Stage 되지 않았는데
이부분도 다시 올렸습니다.

----------------------------------------------------------------------------------------
FIX

등록한 사용자가 0명인 채널에도 알림이벤트 발생 log 가 기록되는 문제 수정했습니다.

```